### PR TITLE
Overhaul

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -13,6 +13,7 @@ django = "*"
 djangorestframework = "*"
 authlib = "*"
 requests = "*"
+pyjwt = "*"
 
 [requires]
 python_version = "3.10"

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "67c6febe5c649b95466ed26e798fb4ab9799a9c93b84c02b8ad8d5c4e8f87eb4"
+            "sha256": "fd7a3fa4781647e2ffb20489fae3a56331f0463974d4fbad6af2c4a28e70386f"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -18,139 +18,174 @@
     "default": {
         "asgiref": {
             "hashes": [
-                "sha256:4ef1ab46b484e3c706329cedeff284a5d40824200638503f5768edb6de7d58e9",
-                "sha256:ffc141aa908e6f175673e7b1b3b7af4fdb0ecb738fc5c8b88f69f055c2415214"
+                "sha256:71e68008da809b957b7ee4b43dbccff33d1b23519fb8344e33f049897077afac",
+                "sha256:9567dfe7bd8d3c8c892227827c41cce860b368104c3431da67a0c5a65a949506"
             ],
-            "markers": "python_version >= '3.6'",
-            "version": "==3.4.1"
+            "version": "==3.6.0"
         },
         "authlib": {
             "hashes": [
-                "sha256:b83cf6360c8e92b0e9df0d1f32d675790bcc4e3c03977499b1eed24dcdef4252",
-                "sha256:ecf4a7a9f2508c0bb07e93a752dd3c495cfaffc20e864ef0ffc95e3f40d2abaf"
+                "sha256:4ddf4fd6cfa75c9a460b361d4bd9dac71ffda0be879dbe4292a02e92349ad55a",
+                "sha256:4fa3e80883a5915ef9f5bc28630564bc4ed5b5af39812a3ff130ec76bd631e9d"
             ],
             "index": "pypi",
-            "version": "==0.15.5"
+            "version": "==1.2.0"
+        },
+        "backports.zoneinfo": {
+            "hashes": [
+                "sha256:17746bd546106fa389c51dbea67c8b7c8f0d14b5526a579ca6ccf5ed72c526cf",
+                "sha256:1b13e654a55cd45672cb54ed12148cd33628f672548f373963b0bff67b217328",
+                "sha256:1c5742112073a563c81f786e77514969acb58649bcdf6cdf0b4ed31a348d4546",
+                "sha256:4a0f800587060bf8880f954dbef70de6c11bbe59c673c3d818921f042f9954a6",
+                "sha256:5c144945a7752ca544b4b78c8c41544cdfaf9786f25fe5ffb10e838e19a27570",
+                "sha256:7b0a64cda4145548fed9efc10322770f929b944ce5cee6c0dfe0c87bf4c0c8c9",
+                "sha256:8439c030a11780786a2002261569bdf362264f605dfa4d65090b64b05c9f79a7",
+                "sha256:8961c0f32cd0336fb8e8ead11a1f8cd99ec07145ec2931122faaac1c8f7fd987",
+                "sha256:89a48c0d158a3cc3f654da4c2de1ceba85263fafb861b98b59040a5086259722",
+                "sha256:a76b38c52400b762e48131494ba26be363491ac4f9a04c1b7e92483d169f6582",
+                "sha256:da6013fd84a690242c310d77ddb8441a559e9cb3d3d59ebac9aca1a57b2e18bc",
+                "sha256:e55b384612d93be96506932a786bbcde5a2db7a9e6a4bb4bffe8b733f5b9036b",
+                "sha256:e81b76cace8eda1fca50e345242ba977f9be6ae3945af8d46326d776b4cf78d1",
+                "sha256:e8236383a20872c0cdf5a62b554b27538db7fa1bbec52429d8d106effbaeca08",
+                "sha256:f04e857b59d9d1ccc39ce2da1021d196e47234873820cbeaad210724b1ee28ac",
+                "sha256:fadbfe37f74051d024037f223b8e001611eac868b5c5b06144ef4d8b799862f2"
+            ],
+            "markers": "python_version < '3.9'",
+            "version": "==0.2.1"
         },
         "certifi": {
             "hashes": [
-                "sha256:78884e7c1d4b00ce3cea67b44566851c4343c120abd683433ce934a68ea58872",
-                "sha256:d62a0163eb4c2344ac042ab2bdf75399a71a2d8c7d47eac2e2ee91b9d6339569"
+                "sha256:35824b4c3a97115964b408844d64aa14db1cc518f6562e8d7261699d1350a9e3",
+                "sha256:4ad3232f5e926d6718ec31cfc1fcadfde020920e278684144551c91769c7bc18"
             ],
-            "version": "==2021.10.8"
+            "version": "==2022.12.7"
         },
         "cffi": {
             "hashes": [
-                "sha256:00c878c90cb53ccfaae6b8bc18ad05d2036553e6d9d1d9dbcf323bbe83854ca3",
-                "sha256:0104fb5ae2391d46a4cb082abdd5c69ea4eab79d8d44eaaf79f1b1fd806ee4c2",
-                "sha256:06c48159c1abed75c2e721b1715c379fa3200c7784271b3c46df01383b593636",
-                "sha256:0808014eb713677ec1292301ea4c81ad277b6cdf2fdd90fd540af98c0b101d20",
-                "sha256:10dffb601ccfb65262a27233ac273d552ddc4d8ae1bf93b21c94b8511bffe728",
-                "sha256:14cd121ea63ecdae71efa69c15c5543a4b5fbcd0bbe2aad864baca0063cecf27",
-                "sha256:17771976e82e9f94976180f76468546834d22a7cc404b17c22df2a2c81db0c66",
-                "sha256:181dee03b1170ff1969489acf1c26533710231c58f95534e3edac87fff06c443",
-                "sha256:23cfe892bd5dd8941608f93348c0737e369e51c100d03718f108bf1add7bd6d0",
-                "sha256:263cc3d821c4ab2213cbe8cd8b355a7f72a8324577dc865ef98487c1aeee2bc7",
-                "sha256:2756c88cbb94231c7a147402476be2c4df2f6078099a6f4a480d239a8817ae39",
-                "sha256:27c219baf94952ae9d50ec19651a687b826792055353d07648a5695413e0c605",
-                "sha256:2a23af14f408d53d5e6cd4e3d9a24ff9e05906ad574822a10563efcef137979a",
-                "sha256:31fb708d9d7c3f49a60f04cf5b119aeefe5644daba1cd2a0fe389b674fd1de37",
-                "sha256:3415c89f9204ee60cd09b235810be700e993e343a408693e80ce7f6a40108029",
-                "sha256:3773c4d81e6e818df2efbc7dd77325ca0dcb688116050fb2b3011218eda36139",
-                "sha256:3b96a311ac60a3f6be21d2572e46ce67f09abcf4d09344c49274eb9e0bf345fc",
-                "sha256:3f7d084648d77af029acb79a0ff49a0ad7e9d09057a9bf46596dac9514dc07df",
-                "sha256:41d45de54cd277a7878919867c0f08b0cf817605e4eb94093e7516505d3c8d14",
-                "sha256:4238e6dab5d6a8ba812de994bbb0a79bddbdf80994e4ce802b6f6f3142fcc880",
-                "sha256:45db3a33139e9c8f7c09234b5784a5e33d31fd6907800b316decad50af323ff2",
-                "sha256:45e8636704eacc432a206ac7345a5d3d2c62d95a507ec70d62f23cd91770482a",
-                "sha256:4958391dbd6249d7ad855b9ca88fae690783a6be9e86df65865058ed81fc860e",
-                "sha256:4a306fa632e8f0928956a41fa8e1d6243c71e7eb59ffbd165fc0b41e316b2474",
-                "sha256:57e9ac9ccc3101fac9d6014fba037473e4358ef4e89f8e181f8951a2c0162024",
-                "sha256:59888172256cac5629e60e72e86598027aca6bf01fa2465bdb676d37636573e8",
-                "sha256:5e069f72d497312b24fcc02073d70cb989045d1c91cbd53979366077959933e0",
-                "sha256:64d4ec9f448dfe041705426000cc13e34e6e5bb13736e9fd62e34a0b0c41566e",
-                "sha256:6dc2737a3674b3e344847c8686cf29e500584ccad76204efea14f451d4cc669a",
-                "sha256:74fdfdbfdc48d3f47148976f49fab3251e550a8720bebc99bf1483f5bfb5db3e",
-                "sha256:75e4024375654472cc27e91cbe9eaa08567f7fbdf822638be2814ce059f58032",
-                "sha256:786902fb9ba7433aae840e0ed609f45c7bcd4e225ebb9c753aa39725bb3e6ad6",
-                "sha256:8b6c2ea03845c9f501ed1313e78de148cd3f6cad741a75d43a29b43da27f2e1e",
-                "sha256:91d77d2a782be4274da750752bb1650a97bfd8f291022b379bb8e01c66b4e96b",
-                "sha256:91ec59c33514b7c7559a6acda53bbfe1b283949c34fe7440bcf917f96ac0723e",
-                "sha256:920f0d66a896c2d99f0adbb391f990a84091179542c205fa53ce5787aff87954",
-                "sha256:a5263e363c27b653a90078143adb3d076c1a748ec9ecc78ea2fb916f9b861962",
-                "sha256:abb9a20a72ac4e0fdb50dae135ba5e77880518e742077ced47eb1499e29a443c",
-                "sha256:c2051981a968d7de9dd2d7b87bcb9c939c74a34626a6e2f8181455dd49ed69e4",
-                "sha256:c21c9e3896c23007803a875460fb786118f0cdd4434359577ea25eb556e34c55",
-                "sha256:c2502a1a03b6312837279c8c1bd3ebedf6c12c4228ddbad40912d671ccc8a962",
-                "sha256:d4d692a89c5cf08a8557fdeb329b82e7bf609aadfaed6c0d79f5a449a3c7c023",
-                "sha256:da5db4e883f1ce37f55c667e5c0de439df76ac4cb55964655906306918e7363c",
-                "sha256:e7022a66d9b55e93e1a845d8c9eba2a1bebd4966cd8bfc25d9cd07d515b33fa6",
-                "sha256:ef1f279350da2c586a69d32fc8733092fd32cc8ac95139a00377841f59a3f8d8",
-                "sha256:f54a64f8b0c8ff0b64d18aa76675262e1700f3995182267998c31ae974fbc382",
-                "sha256:f5c7150ad32ba43a07c4479f40241756145a1f03b43480e058cfd862bf5041c7",
-                "sha256:f6f824dc3bce0edab5f427efcfb1d63ee75b6fcb7282900ccaf925be84efb0fc",
-                "sha256:fd8a250edc26254fe5b33be00402e6d287f562b6a5b2152dec302fa15bb3e997",
-                "sha256:ffaa5c925128e29efbde7301d8ecaf35c8c60ffbcd6a1ffd3a552177c8e5e796"
+                "sha256:00a9ed42e88df81ffae7a8ab6d9356b371399b91dbdf0c3cb1e84c03a13aceb5",
+                "sha256:03425bdae262c76aad70202debd780501fabeaca237cdfddc008987c0e0f59ef",
+                "sha256:04ed324bda3cda42b9b695d51bb7d54b680b9719cfab04227cdd1e04e5de3104",
+                "sha256:0e2642fe3142e4cc4af0799748233ad6da94c62a8bec3a6648bf8ee68b1c7426",
+                "sha256:173379135477dc8cac4bc58f45db08ab45d228b3363adb7af79436135d028405",
+                "sha256:198caafb44239b60e252492445da556afafc7d1e3ab7a1fb3f0584ef6d742375",
+                "sha256:1e74c6b51a9ed6589199c787bf5f9875612ca4a8a0785fb2d4a84429badaf22a",
+                "sha256:2012c72d854c2d03e45d06ae57f40d78e5770d252f195b93f581acf3ba44496e",
+                "sha256:21157295583fe8943475029ed5abdcf71eb3911894724e360acff1d61c1d54bc",
+                "sha256:2470043b93ff09bf8fb1d46d1cb756ce6132c54826661a32d4e4d132e1977adf",
+                "sha256:285d29981935eb726a4399badae8f0ffdff4f5050eaa6d0cfc3f64b857b77185",
+                "sha256:30d78fbc8ebf9c92c9b7823ee18eb92f2e6ef79b45ac84db507f52fbe3ec4497",
+                "sha256:320dab6e7cb2eacdf0e658569d2575c4dad258c0fcc794f46215e1e39f90f2c3",
+                "sha256:33ab79603146aace82c2427da5ca6e58f2b3f2fb5da893ceac0c42218a40be35",
+                "sha256:3548db281cd7d2561c9ad9984681c95f7b0e38881201e157833a2342c30d5e8c",
+                "sha256:3799aecf2e17cf585d977b780ce79ff0dc9b78d799fc694221ce814c2c19db83",
+                "sha256:39d39875251ca8f612b6f33e6b1195af86d1b3e60086068be9cc053aa4376e21",
+                "sha256:3b926aa83d1edb5aa5b427b4053dc420ec295a08e40911296b9eb1b6170f6cca",
+                "sha256:3bcde07039e586f91b45c88f8583ea7cf7a0770df3a1649627bf598332cb6984",
+                "sha256:3d08afd128ddaa624a48cf2b859afef385b720bb4b43df214f85616922e6a5ac",
+                "sha256:3eb6971dcff08619f8d91607cfc726518b6fa2a9eba42856be181c6d0d9515fd",
+                "sha256:40f4774f5a9d4f5e344f31a32b5096977b5d48560c5592e2f3d2c4374bd543ee",
+                "sha256:4289fc34b2f5316fbb762d75362931e351941fa95fa18789191b33fc4cf9504a",
+                "sha256:470c103ae716238bbe698d67ad020e1db9d9dba34fa5a899b5e21577e6d52ed2",
+                "sha256:4f2c9f67e9821cad2e5f480bc8d83b8742896f1242dba247911072d4fa94c192",
+                "sha256:50a74364d85fd319352182ef59c5c790484a336f6db772c1a9231f1c3ed0cbd7",
+                "sha256:54a2db7b78338edd780e7ef7f9f6c442500fb0d41a5a4ea24fff1c929d5af585",
+                "sha256:5635bd9cb9731e6d4a1132a498dd34f764034a8ce60cef4f5319c0541159392f",
+                "sha256:59c0b02d0a6c384d453fece7566d1c7e6b7bae4fc5874ef2ef46d56776d61c9e",
+                "sha256:5d598b938678ebf3c67377cdd45e09d431369c3b1a5b331058c338e201f12b27",
+                "sha256:5df2768244d19ab7f60546d0c7c63ce1581f7af8b5de3eb3004b9b6fc8a9f84b",
+                "sha256:5ef34d190326c3b1f822a5b7a45f6c4535e2f47ed06fec77d3d799c450b2651e",
+                "sha256:6975a3fac6bc83c4a65c9f9fcab9e47019a11d3d2cf7f3c0d03431bf145a941e",
+                "sha256:6c9a799e985904922a4d207a94eae35c78ebae90e128f0c4e521ce339396be9d",
+                "sha256:70df4e3b545a17496c9b3f41f5115e69a4f2e77e94e1d2a8e1070bc0c38c8a3c",
+                "sha256:7473e861101c9e72452f9bf8acb984947aa1661a7704553a9f6e4baa5ba64415",
+                "sha256:8102eaf27e1e448db915d08afa8b41d6c7ca7a04b7d73af6514df10a3e74bd82",
+                "sha256:87c450779d0914f2861b8526e035c5e6da0a3199d8f1add1a665e1cbc6fc6d02",
+                "sha256:8b7ee99e510d7b66cdb6c593f21c043c248537a32e0bedf02e01e9553a172314",
+                "sha256:91fc98adde3d7881af9b59ed0294046f3806221863722ba7d8d120c575314325",
+                "sha256:94411f22c3985acaec6f83c6df553f2dbe17b698cc7f8ae751ff2237d96b9e3c",
+                "sha256:98d85c6a2bef81588d9227dde12db8a7f47f639f4a17c9ae08e773aa9c697bf3",
+                "sha256:9ad5db27f9cabae298d151c85cf2bad1d359a1b9c686a275df03385758e2f914",
+                "sha256:a0b71b1b8fbf2b96e41c4d990244165e2c9be83d54962a9a1d118fd8657d2045",
+                "sha256:a0f100c8912c114ff53e1202d0078b425bee3649ae34d7b070e9697f93c5d52d",
+                "sha256:a591fe9e525846e4d154205572a029f653ada1a78b93697f3b5a8f1f2bc055b9",
+                "sha256:a5c84c68147988265e60416b57fc83425a78058853509c1b0629c180094904a5",
+                "sha256:a66d3508133af6e8548451b25058d5812812ec3798c886bf38ed24a98216fab2",
+                "sha256:a8c4917bd7ad33e8eb21e9a5bbba979b49d9a97acb3a803092cbc1133e20343c",
+                "sha256:b3bbeb01c2b273cca1e1e0c5df57f12dce9a4dd331b4fa1635b8bec26350bde3",
+                "sha256:cba9d6b9a7d64d4bd46167096fc9d2f835e25d7e4c121fb2ddfc6528fb0413b2",
+                "sha256:cc4d65aeeaa04136a12677d3dd0b1c0c94dc43abac5860ab33cceb42b801c1e8",
+                "sha256:ce4bcc037df4fc5e3d184794f27bdaab018943698f4ca31630bc7f84a7b69c6d",
+                "sha256:cec7d9412a9102bdc577382c3929b337320c4c4c4849f2c5cdd14d7368c5562d",
+                "sha256:d400bfb9a37b1351253cb402671cea7e89bdecc294e8016a707f6d1d8ac934f9",
+                "sha256:d61f4695e6c866a23a21acab0509af1cdfd2c013cf256bbf5b6b5e2695827162",
+                "sha256:db0fbb9c62743ce59a9ff687eb5f4afbe77e5e8403d6697f7446e5f609976f76",
+                "sha256:dd86c085fae2efd48ac91dd7ccffcfc0571387fe1193d33b6394db7ef31fe2a4",
+                "sha256:e00b098126fd45523dd056d2efba6c5a63b71ffe9f2bbe1a4fe1716e1d0c331e",
+                "sha256:e229a521186c75c8ad9490854fd8bbdd9a0c9aa3a524326b55be83b54d4e0ad9",
+                "sha256:e263d77ee3dd201c3a142934a086a4450861778baaeeb45db4591ef65550b0a6",
+                "sha256:ed9cb427ba5504c1dc15ede7d516b84757c3e3d7868ccc85121d9310d27eed0b",
+                "sha256:fa6693661a4c91757f4412306191b6dc88c1703f780c8234035eac011922bc01",
+                "sha256:fcd131dd944808b5bdb38e6f5b53013c5aa4f334c5cad0c72742f6eba4b73db0"
             ],
-            "version": "==1.15.0"
+            "version": "==1.15.1"
         },
         "charset-normalizer": {
             "hashes": [
-                "sha256:1eecaa09422db5be9e29d7fc65664e6c33bd06f9ced7838578ba40d58bdf3721",
-                "sha256:b0b883e8e874edfdece9c28f314e3dd5badf067342e42fb162203335ae61aa2c"
+                "sha256:5a3d016c7c547f69d6f81fb0db9449ce888b418b5b9952cc5e6e66843e9dd845",
+                "sha256:83e9a75d1911279afd89352c68b45348559d1fc0506b054b346651b5e7fee29f"
             ],
-            "markers": "python_version >= '3'",
-            "version": "==2.0.9"
+            "version": "==2.1.1"
         },
         "cryptography": {
             "hashes": [
-                "sha256:0a817b961b46894c5ca8a66b599c745b9a3d9f822725221f0e0fe49dc043a3a3",
-                "sha256:2d87cdcb378d3cfed944dac30596da1968f88fb96d7fc34fdae30a99054b2e31",
-                "sha256:30ee1eb3ebe1644d1c3f183d115a8c04e4e603ed6ce8e394ed39eea4a98469ac",
-                "sha256:391432971a66cfaf94b21c24ab465a4cc3e8bf4a939c1ca5c3e3a6e0abebdbcf",
-                "sha256:39bdf8e70eee6b1c7b289ec6e5d84d49a6bfa11f8b8646b5b3dfe41219153316",
-                "sha256:4caa4b893d8fad33cf1964d3e51842cd78ba87401ab1d2e44556826df849a8ca",
-                "sha256:53e5c1dc3d7a953de055d77bef2ff607ceef7a2aac0353b5d630ab67f7423638",
-                "sha256:596f3cd67e1b950bc372c33f1a28a0692080625592ea6392987dba7f09f17a94",
-                "sha256:5d59a9d55027a8b88fd9fd2826c4392bd487d74bf628bb9d39beecc62a644c12",
-                "sha256:6c0c021f35b421ebf5976abf2daacc47e235f8b6082d3396a2fe3ccd537ab173",
-                "sha256:73bc2d3f2444bcfeac67dd130ff2ea598ea5f20b40e36d19821b4df8c9c5037b",
-                "sha256:74d6c7e80609c0f4c2434b97b80c7f8fdfaa072ca4baab7e239a15d6d70ed73a",
-                "sha256:7be0eec337359c155df191d6ae00a5e8bbb63933883f4f5dffc439dac5348c3f",
-                "sha256:94ae132f0e40fe48f310bba63f477f14a43116f05ddb69d6fa31e93f05848ae2",
-                "sha256:bb5829d027ff82aa872d76158919045a7c1e91fbf241aec32cb07956e9ebd3c9",
-                "sha256:ca238ceb7ba0bdf6ce88c1b74a87bffcee5afbfa1e41e173b1ceb095b39add46",
-                "sha256:ca28641954f767f9822c24e927ad894d45d5a1e501767599647259cbf030b903",
-                "sha256:e0344c14c9cb89e76eb6a060e67980c9e35b3f36691e15e1b7a9e58a0a6c6dc3",
-                "sha256:ebc15b1c22e55c4d5566e3ca4db8689470a0ca2babef8e3a9ee057a8b82ce4b1",
-                "sha256:ec63da4e7e4a5f924b90af42eddf20b698a70e58d86a72d943857c4c6045b3ee"
+                "sha256:1a6915075c6d3a5e1215eab5d99bcec0da26036ff2102a1038401d6ef5bef25b",
+                "sha256:1ee1fd0de9851ff32dbbb9362a4d833b579b4a6cc96883e8e6d2ff2a6bc7104f",
+                "sha256:407cec680e811b4fc829de966f88a7c62a596faa250fc1a4b520a0355b9bc190",
+                "sha256:50386acb40fbabbceeb2986332f0287f50f29ccf1497bae31cf5c3e7b4f4b34f",
+                "sha256:6f97109336df5c178ee7c9c711b264c502b905c2d2a29ace99ed761533a3460f",
+                "sha256:754978da4d0457e7ca176f58c57b1f9de6556591c19b25b8bcce3c77d314f5eb",
+                "sha256:76c24dd4fd196a80f9f2f5405a778a8ca132f16b10af113474005635fe7e066c",
+                "sha256:7dacfdeee048814563eaaec7c4743c8aea529fe3dd53127313a792f0dadc1773",
+                "sha256:80ee674c08aaef194bc4627b7f2956e5ba7ef29c3cc3ca488cf15854838a8f72",
+                "sha256:844ad4d7c3850081dffba91cdd91950038ee4ac525c575509a42d3fc806b83c8",
+                "sha256:875aea1039d78557c7c6b4db2fe0e9d2413439f4676310a5f269dd342ca7a717",
+                "sha256:887cbc1ea60786e534b00ba8b04d1095f4272d380ebd5f7a7eb4cc274710fad9",
+                "sha256:ad04f413436b0781f20c52a661660f1e23bcd89a0e9bb1d6d20822d048cf2856",
+                "sha256:bae6c7f4a36a25291b619ad064a30a07110a805d08dc89984f4f441f6c1f3f96",
+                "sha256:c52a1a6f81e738d07f43dab57831c29e57d21c81a942f4602fac7ee21b27f288",
+                "sha256:e0a05aee6a82d944f9b4edd6a001178787d1546ec7c6223ee9a848a7ade92e39",
+                "sha256:e324de6972b151f99dc078defe8fb1b0a82c6498e37bff335f5bc6b1e3ab5a1e",
+                "sha256:e5d71c5d5bd5b5c3eebcf7c5c2bb332d62ec68921a8c593bea8c394911a005ce",
+                "sha256:f3ed2d864a2fa1666e749fe52fb8e23d8e06b8012e8bd8147c73797c506e86f1",
+                "sha256:f671c1bb0d6088e94d61d80c606d65baacc0d374e67bf895148883461cd848de",
+                "sha256:f6c0db08d81ead9576c4d94bbb27aed8d7a430fa27890f39084c2d0e2ec6b0df",
+                "sha256:f964c7dcf7802d133e8dbd1565914fa0194f9d683d82411989889ecd701e8adf",
+                "sha256:fec8b932f51ae245121c4671b4bbc030880f363354b2f0e0bd1366017d891458"
             ],
-            "markers": "python_version >= '3.6'",
-            "version": "==36.0.1"
+            "version": "==39.0.0"
         },
         "django": {
             "hashes": [
-                "sha256:59304646ebc6a77b9b6a59adc67d51ecb03c5e3d63ed1f14c909cdfda84e8010",
-                "sha256:d5a8a14da819a8b9237ee4d8c78dfe056ff6e8a7511987be627192225113ee75"
+                "sha256:4b214a05fe4c99476e99e2445c8b978c8369c18d4dea8e22ec412862715ad763",
+                "sha256:ff56ebd7ead0fd5dbe06fe157b0024a7aaea2e0593bb3785fb594cf94dad58ef"
             ],
             "index": "pypi",
-            "version": "==4.0"
+            "version": "==4.1.5"
         },
         "djangorestframework": {
             "hashes": [
-                "sha256:0c33407ce23acc68eca2a6e46424b008c9c02eceb8cf18581921d0092bc1f2ee",
-                "sha256:24c4bf58ed7e85d1fe4ba250ab2da926d263cd57d64b03e8dcef0ac683f8b1aa"
+                "sha256:579a333e6256b09489cbe0a067e66abe55c6595d8926be6b99423786334350c8",
+                "sha256:eb63f58c9f218e1a7d064d17a70751f528ed4e1d35547fdade9aaf4cd103fd08"
             ],
             "index": "pypi",
-            "version": "==3.13.1"
+            "version": "==3.14.0"
         },
         "idna": {
             "hashes": [
-                "sha256:84d9dd047ffa80596e0f246e2eab0b391788b0503584e8945f2368256d2735ff",
-                "sha256:9d643ff0a55b762d5cdb124b8eaa99c66322e2157b69160bc32796e824360e6d"
+                "sha256:814f528e8dead7d329833b91c5faa87d60bf71824cd12a7530b5526063d02cb4",
+                "sha256:90b77e79eaa3eba6de819a0c442c0b4ceefc341a7a2ab77d7562bf49f425c5c2"
             ],
-            "markers": "python_version >= '3'",
-            "version": "==3.3"
+            "version": "==3.4"
         },
         "pycparser": {
             "hashes": [
@@ -159,164 +194,167 @@
             ],
             "version": "==2.21"
         },
+        "pyjwt": {
+            "hashes": [
+                "sha256:69285c7e31fc44f68a1feb309e948e0df53259d579295e6cfe2b1792329f05fd",
+                "sha256:d83c3d892a77bbb74d3e1a2cfa90afaadb60945205d1095d9221f04466f64c14"
+            ],
+            "index": "pypi",
+            "version": "==2.6.0"
+        },
         "pytz": {
             "hashes": [
-                "sha256:3672058bc3453457b622aab7a1c3bfd5ab0bdae451512f6cf25f64ed37f5b87c",
-                "sha256:acad2d8b20a1af07d4e4c9d2e9285c5ed9104354062f275f3fcd88dcef4f1326"
+                "sha256:7ccfae7b4b2c067464a6733c6261673fdb8fd1be905460396b97a073e9fa683a",
+                "sha256:93007def75ae22f7cd991c84e02d434876818661f8df9ad5df9e950ff4e52cfd"
             ],
-            "version": "==2021.3"
+            "version": "==2022.7"
         },
         "requests": {
             "hashes": [
-                "sha256:6c1246513ecd5ecd4528a0906f910e8f0f9c6b8ec72030dc9fd154dc1a6efd24",
-                "sha256:b8aa58f8cf793ffd8782d3d8cb19e66ef36f7aba4353eec859e74678b01b07a7"
+                "sha256:7c5599b102feddaa661c826c56ab4fee28bfd17f5abca1ebbe3e7f19d7c97983",
+                "sha256:8fefa2a1a1365bf5520aac41836fbee479da67864514bdb821f31ce07ce65349"
             ],
             "index": "pypi",
-            "version": "==2.26.0"
+            "version": "==2.28.1"
         },
         "sqlparse": {
             "hashes": [
-                "sha256:0c00730c74263a94e5a9919ade150dfc3b19c574389985446148402998287dae",
-                "sha256:48719e356bb8b42991bdbb1e8b83223757b93789c00910a616a071910ca4a64d"
+                "sha256:0323c0ec29cd52bceabc1b4d9d579e311f3e4961b98d174201d5622a23b85e34",
+                "sha256:69ca804846bb114d2ec380e4360a8a340db83f0ccf3afceeb1404df028f57268"
             ],
-            "markers": "python_version >= '3.5'",
-            "version": "==0.4.2"
+            "version": "==0.4.3"
         },
         "urllib3": {
             "hashes": [
-                "sha256:4987c65554f7a2dbf30c18fd48778ef124af6fab771a377103da0585e2336ece",
-                "sha256:c4fdf4019605b6e5423637e01bc9fe4daef873709a7973e195ceba0a62bbc844"
+                "sha256:47cc05d99aaa09c9e72ed5809b60e7ba354e64b59c9c173ac3018642d8bb41fc",
+                "sha256:c083dd0dce68dbfbe1129d5271cb90f9447dea7d52097c6e0126120c521ddea8"
             ],
-            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4' and python_version < '4'",
-            "version": "==1.26.7"
+            "version": "==1.26.13"
         }
     },
     "develop": {
         "autopep8": {
             "hashes": [
-                "sha256:44f0932855039d2c15c4510d6df665e4730f2b8582704fa48f9c55bd3e17d979",
-                "sha256:ed77137193bbac52d029a52c59bec1b0629b5a186c495f1eb21b126ac466083f"
+                "sha256:be5bc98c33515b67475420b7b1feafc8d32c1a69862498eda4983b45bffd2687",
+                "sha256:d27a8929d8dcd21c0f4b3859d2d07c6c25273727b98afc984c039df0f0d86566"
             ],
             "index": "pypi",
-            "version": "==1.6.0"
+            "version": "==2.0.1"
+        },
+        "cachetools": {
+            "hashes": [
+                "sha256:6a94c6402995a99c3970cc7e4884bb60b4a8639938157eeed436098bf9831757",
+                "sha256:f9f17d2aec496a9aa6b76f53e3b614c965223c061982d434d160f930c698a9db"
+            ],
+            "version": "==5.2.0"
+        },
+        "chardet": {
+            "hashes": [
+                "sha256:0d62712b956bc154f85fb0a266e2a3c5913c2967e00348701b32411d6def31e5",
+                "sha256:362777fb014af596ad31334fde1e8c327dfdb076e1960d1694662d46a6917ab9"
+            ],
+            "version": "==5.1.0"
+        },
+        "colorama": {
+            "hashes": [
+                "sha256:08695f5cb7ed6e0531a20572697297273c47b8cae5a63ffc6d6ed5c201be6e44",
+                "sha256:4f1d9991f5acc0ca119f9d443620b77f9d6b33703e51011c16baf57afb285fc6"
+            ],
+            "version": "==0.4.6"
         },
         "distlib": {
             "hashes": [
-                "sha256:6564fe0a8f51e734df6333d08b8b94d4ea8ee6b99b5ed50613f731fd4089f34b",
-                "sha256:e4b58818180336dc9c529bfb9a0b58728ffc09ad92027a3f30b7cd91e3458579"
+                "sha256:14bad2d9b04d3a36127ac97f30b12a19268f211063d8f8ee4f47108896e11b46",
+                "sha256:f35c4b692542ca110de7ef0bea44d73981caeb34ca0b9b6b2e6d7790dda8f80e"
             ],
-            "version": "==0.3.4"
+            "version": "==0.3.6"
         },
         "filelock": {
             "hashes": [
-                "sha256:38b4f4c989f9d06d44524df1b24bd19e167d851f19b50bf3e3559952dddc5b80",
-                "sha256:cf0fc6a2f8d26bd900f19bf33915ca70ba4dd8c56903eeb14e1e7a2fd7590146"
+                "sha256:7b319f24340b51f55a2bf7a12ac0755a9b03e718311dac567a0f4f7fabd2f5de",
+                "sha256:f58d535af89bb9ad5cd4df046f741f8553a418c01a7856bf0d173bbc9f6bd16d"
             ],
-            "markers": "python_version >= '3.7'",
-            "version": "==3.4.2"
+            "version": "==3.9.0"
         },
         "flake8": {
             "hashes": [
-                "sha256:479b1304f72536a55948cb40a32dce8bb0ffe3501e26eaf292c7e60eb5e0428d",
-                "sha256:806e034dda44114815e23c16ef92f95c91e4c71100ff52813adf7132a6ad870d"
+                "sha256:3833794e27ff64ea4e9cf5d410082a8b97ff1a06c16aa3d2027339cd0f1195c7",
+                "sha256:c61007e76655af75e6785a931f452915b371dc48f56efd765247c8fe68f2b181"
             ],
             "index": "pypi",
-            "version": "==4.0.1"
+            "version": "==6.0.0"
         },
         "mccabe": {
             "hashes": [
-                "sha256:ab8a6258860da4b6677da4bd2fe5dc2c659cff31b3ee4f7f5d64e79735b80d42",
-                "sha256:dd8d182285a0fe56bace7f45b5e7d1a6ebcbf524e8f3bd87eb0f125271b8831f"
+                "sha256:348e0240c33b60bbdf4e523192ef919f28cb2c3d7d5c7794f74009290f236325",
+                "sha256:6c2d30ab6be0e4a46919781807b4f0d834ebdd6c6e3dca0bda5a15f863427b6e"
             ],
-            "version": "==0.6.1"
+            "version": "==0.7.0"
         },
         "packaging": {
             "hashes": [
-                "sha256:dd47c42927d89ab911e606518907cc2d3a1f38bbd026385970643f9c5b8ecfeb",
-                "sha256:ef103e05f519cdc783ae24ea4e2e0f508a9c99b2d4969652eed6a2e1ea5bd522"
+                "sha256:2198ec20bd4c017b8f9717e00f0c8714076fc2fd93816750ab48e2c41de2cfd3",
+                "sha256:957e2148ba0e1a3b282772e791ef1d8083648bc131c8ab0c1feba110ce1146c3"
             ],
-            "markers": "python_version >= '3.6'",
-            "version": "==21.3"
+            "version": "==22.0"
         },
         "platformdirs": {
             "hashes": [
-                "sha256:1d7385c7db91728b83efd0ca99a5afb296cab9d0ed8313a45ed8ba17967ecfca",
-                "sha256:440633ddfebcc36264232365d7840a970e75e1018d15b4327d11f91909045fda"
+                "sha256:83c8f6d04389165de7c9b6f0c682439697887bca0aa2f1c87ef1826be3584490",
+                "sha256:e1fea1fe471b9ff8332e229df3cb7de4f53eeea4998d3b6bfff542115e998bd2"
             ],
-            "markers": "python_version >= '3.7'",
-            "version": "==2.4.1"
+            "version": "==2.6.2"
         },
         "pluggy": {
             "hashes": [
                 "sha256:4224373bacce55f955a878bf9cfa763c1e360858e330072059e10bad68531159",
                 "sha256:74134bbf457f031a36d68416e1509f34bd5ccc019f0bcc952c7b909d06b37bd3"
             ],
-            "markers": "python_version >= '3.6'",
             "version": "==1.0.0"
-        },
-        "py": {
-            "hashes": [
-                "sha256:51c75c4126074b472f746a24399ad32f6053d1b34b68d2fa41e558e6f4a98719",
-                "sha256:607c53218732647dff4acdfcd50cb62615cedf612e72d1724fb1a0cc6405b378"
-            ],
-            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4'",
-            "version": "==1.11.0"
         },
         "pycodestyle": {
             "hashes": [
-                "sha256:720f8b39dde8b293825e7ff02c475f3077124006db4f440dcbc9a20b76548a20",
-                "sha256:eddd5847ef438ea1c7870ca7eb78a9d47ce0cdb4851a5523949f2601d0cbbe7f"
+                "sha256:347187bdb476329d98f695c213d7295a846d1152ff4fe9bacb8a9590b8ee7053",
+                "sha256:8a4eaf0d0495c7395bdab3589ac2db602797d76207242c17d470186815706610"
             ],
-            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4'",
-            "version": "==2.8.0"
+            "version": "==2.10.0"
         },
         "pyflakes": {
             "hashes": [
-                "sha256:05a85c2872edf37a4ed30b0cce2f6093e1d0581f8c19d7393122da7e25b2b24c",
-                "sha256:3bb3a3f256f4b7968c9c788781e4ff07dce46bdf12339dcda61053375426ee2e"
+                "sha256:ec55bf7fe21fff7f1ad2f7da62363d749e2a470500eab1b555334b67aa1ef8cf",
+                "sha256:ec8b276a6b60bd80defed25add7e439881c19e64850afd9b346283d4165fd0fd"
             ],
-            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'",
-            "version": "==2.4.0"
+            "version": "==3.0.1"
         },
-        "pyparsing": {
+        "pyproject-api": {
             "hashes": [
-                "sha256:04ff808a5b90911829c55c4e26f75fa5ca8a2f5f36aa3a51f68e27033341d3e4",
-                "sha256:d9bdec0013ef1eb5a84ab39a3b3868911598afa494f5faa038647101504e2b81"
+                "sha256:093c047d192ceadcab7afd6b501276bf2ce44adf41cb9c313234518cddd20818",
+                "sha256:155d5623453173b7b4e9379a3146ccef2d52335234eb2d03d6ba730e7dad179c"
             ],
-            "markers": "python_version >= '3.6'",
-            "version": "==3.0.6"
+            "version": "==1.2.1"
         },
-        "six": {
+        "tomli": {
             "hashes": [
-                "sha256:1e61c37477a1626458e36f7b1d82aa5c9b094fa4802892072e49de9c60c4c926",
-                "sha256:8abb2f1d86890a2dfb989f9a77cfcfd3e47c2a354b01111771326f8aa26e0254"
+                "sha256:939de3e7a6161af0c887ef91b7d41a53e7c5a1ca976325f429cb46ea9bc30ecc",
+                "sha256:de526c12914f0c550d15924c62d72abc48d6fe7364aa87328337a31007fe8a4f"
             ],
-            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'",
-            "version": "==1.16.0"
-        },
-        "toml": {
-            "hashes": [
-                "sha256:806143ae5bfb6a3c6e736a764057db0e6a0e05e338b5630894a5f779cabb4f9b",
-                "sha256:b3bda1d108d5dd99f4a20d24d9c348e91c4db7ab1b749200bded2f839ccbe68f"
-            ],
-            "markers": "python_version >= '2.6' and python_version not in '3.0, 3.1, 3.2, 3.3'",
-            "version": "==0.10.2"
+            "markers": "python_version < '3.11'",
+            "version": "==2.0.1"
         },
         "tox": {
             "hashes": [
-                "sha256:67e0e32c90e278251fea45b696d0fef3879089ccbe979b0c556d35d5a70e2993",
-                "sha256:be3362472a33094bce26727f5f771ca0facf6dafa217f65875314e9a6600c95c"
+                "sha256:3910e7ddf260de9004738a416f2efdbca21ad7f35d279f8a323117256696535f",
+                "sha256:aa1c07530f07265d025d534715f5e8d522606db71568cf6acbf7eadc30a8d0ed"
             ],
             "index": "pypi",
-            "version": "==3.24.5"
+            "version": "==4.1.2"
         },
         "virtualenv": {
             "hashes": [
-                "sha256:a5bb9afc076462ea736b0c060829ed6aef707413d0e5946294cc26e3c821436a",
-                "sha256:d51ae01ef49e7de4d2b9d85b4926ac5aabc3f3879a4b4e4c4a8027fa2f0e4f6a"
+                "sha256:ce3b1684d6e1a20a3e5ed36795a97dfc6af29bc3970ca8dab93e11ac6094b3c4",
+                "sha256:f8b927684efc6f1cc206c9db297a570ab9ad0e51c16fa9e45487d36d1905c058"
             ],
-            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4'",
-            "version": "==20.12.1"
+            "version": "==20.17.1"
         }
     }
 }

--- a/README.md
+++ b/README.md
@@ -80,10 +80,16 @@ OIDC_AUTH = {
 
 ## User authentication
 
-By default, this plugin does not authenticate a user. As long as the token itself is validated succesfully, it will be a success. This will cause problems if your permission classes require a user to be authenticated, or your API in general requires a User to be authenticated. In order to authenticate a user, a custom function can be defined in the
+By default, this plugin does not authenticate a user. As long as the token itself is validated succesfully,
+it will be a success. This will cause problems if your permission classes require a user to be authenticated,
+or your API in general requires a User to be authenticated. In order to authenticate a user, a custom
+function can be defined in the
 `OIDC_RESOLVE_USER_FUNCTION` setting. An example can look like this:
 
 ```
+from django.contrib.auth import get_user_model
+from rest_framework.exceptions import AuthenticationFailed
+
 def get_user_by_id(request, id_token)
     User = get_user_model()
     try:
@@ -95,7 +101,19 @@ def get_user_by_id(request, id_token)
 
 ```
 
-This will authenticate as the user with a username matching the `sub` claim in the token. If no such user exists, the authentication fails.
+This will authenticate as the user with a username matching the `sub` claim in the token. If no such user
+exists, the authentication fails. Using the Django user models will require the `django.contrib.auth`
+and`django.contrib.contenttypes` apps to be configured in the django `settings.py` file like so:
+
+```
+INSTALLED_APPS = (
+    ...
+    'django.contrib.auth',
+    'django.contrib.contenttypes',
+    ...
+)
+```
+
 
 # Running tests
 
@@ -115,7 +133,7 @@ from django.test import TestCase
 class MyTestCase(AuthenticationTestCaseMixin, TestCase):
     def test_example_cache_of_valid_bearer_token(self):
         self.responder.set_response(
-            'http://example.com/userinfo', {'sub': self.user.username})
+            'http://example.com/userinfo', {'sub': self.username})
         auth = 'Bearer egergerg'
         resp = self.client.get('/test/', HTTP_AUTHORIZATION=auth)
         self.assertEqual(resp.status_code, 200)

--- a/README.md
+++ b/README.md
@@ -20,9 +20,6 @@ Configure authentication for Django REST Framework in settings.py:
 
 ```py
 REST_FRAMEWORK = {
-    'DEFAULT_PERMISSION_CLASSES': (
-        'rest_framework.permissions.IsAuthenticated',
-    ),
     'DEFAULT_AUTHENTICATION_CLASSES': (
         # ...
         'oidc_auth.authentication.JSONWebTokenAuthentication',

--- a/README.md
+++ b/README.md
@@ -38,33 +38,31 @@ registered as the default authentication classes.
 And configure the module itself in settings.py:
 ```py
 OIDC_AUTH = {
-    # The Claims Options can now be defined by a static string.
-    # It is recommended to set a required value for the 'aud' claim.
-    # The ISSUERS setting is used to configure the 'iss' claim option,
-    # so setting the 'iss' claim here will override this automatic configuration.
+    # The Claims Options can now be defined by a static string
+    # The ISSUERS setting is used to configure the 'iss' and 'aud' claim options,
+    # so do not set these claims here unless you know what you are doing
     # ref: https://docs.authlib.org/en/latest/jose/jwt.html#jwt-payload-claims-validation
     'OIDC_CLAIMS_OPTIONS': {
-        'aud': {
-            'essential': True,
-            'value': "your-service-name",
-        },
         'nbf': {
             'essential': True,
         },
     },
-    # Dict of issuers mapping to key source. key can either be type PEM, then the key value
-    # should be a string containing a public key in PEM format. if type is JWKS, then key should
-    # a url for a JWKS endpoint
+    # Dict of issuers mapping to key source. `type` can be either `PEM` or `JWKS`. If `PEM`, then the `key` value
+    # should be a string containing a public key in PEM format. For `JWKS` it should be the URL for a JWKS endpoint.
+    # `aud` must also be configured per issuer. This should match the value the token issuer sets for the `aud` claim
+    # in the issued tokens.
     'ISSUERS': {
         'issuer1': {
             'type': "PEM",
+            'aud': "your-service-name-for-issuer1",
             'key': """-----BEGIN RSA PUBLIC KEY-----
 publickeydatahere..
------END RSA PUBLIC KEY-----"""
+-----END RSA PUBLIC KEY-----""",
         },
         'issuer2': {
             'type': "JWKS",
-            'key': "http://example.com/openid/jwks"
+            'aud': "your-service-name-for-issuer2",
+            'key': "http://example.com/openid/jwks",
         }
     },
 

--- a/README.md
+++ b/README.md
@@ -107,10 +107,9 @@ and`django.contrib.contenttypes` apps to be configured in the django `settings.p
 
 ```
 INSTALLED_APPS = (
-    ...
+    #  ...
     'django.contrib.auth',
     'django.contrib.contenttypes',
-    ...
 )
 ```
 

--- a/README.md
+++ b/README.md
@@ -38,9 +38,20 @@ registered as the default authentication classes.
 And configure the module itself in settings.py:
 ```py
 OIDC_AUTH = {
-    # Will only accept tokens with 'aud' claim that matches a string in this list
-    'AUDIENCES': ['myapp'],
-
+    # The Claims Options can now be defined by a static string.
+    # It is recommended to set a required value for the 'aud' claim.
+    # The ISSUERS setting is used to configure the 'iss' claim option,
+    # so setting the 'iss' claim here will override this automatic configuration.
+    # ref: https://docs.authlib.org/en/latest/jose/jwt.html#jwt-payload-claims-validation
+    'OIDC_CLAIMS_OPTIONS': {
+        'aud': {
+            'essential': True,
+            'value': "your-service-name",
+        },
+        'nbf': {
+            'essential': True,
+        },
+    },
     # Dict of issuers mapping to key source. key can either be type PEM, then the key value
     # should be a string containing a public key in PEM format. if type is JWKS, then key should
     # a url for a JWKS endpoint

--- a/README.md
+++ b/README.md
@@ -38,8 +38,8 @@ registered as the default authentication classes.
 And configure the module itself in settings.py:
 ```py
 OIDC_AUTH = {
-    # Will only accept tokens with 'aud' claim that matches this
-    'AUDIENCE': 'myapp',
+    # Will only accept tokens with 'aud' claim that matches a string in this list
+    'AUDIENCES': ['myapp'],
 
     # Dict of issuers mapping to key source. key can either be type PEM, then the key value
     # should be a string containing a public key in PEM format. if type is JWKS, then key should

--- a/README.md
+++ b/README.md
@@ -1,5 +1,8 @@
 # OpenID Connect authentication for Django Rest Framework
 
+This is a fork of the original [OpenID Connect authentication for Django Rest Framework
+by ByteInternet ](https://github.com/Uninett/drf-oidc-auth).
+
 This package contains an authentication mechanism for authenticating
 users of a REST API using tokens obtained from OpenID Connect.
 

--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ OIDC_AUTH = {
     # return a User object. The default implementation tries to find the user
     # based on username (natural key) taken from the 'sub'-claim of the
     # id_token.
-    'OIDC_RESOLVE_USER_FUNCTION': 'oidc_auth.authentication.get_user_by_id',
+    'OIDC_RESOLVE_USER_FUNCTION': 'oidc_auth.authentication.get_user_none',
 
     # (Optional) Time before signing keys will be refreshed (default 24 hrs)
     'OIDC_JWKS_EXPIRATION_TIME': 24*60*60,
@@ -76,6 +76,25 @@ OIDC_AUTH = {
     'OIDC_CACHE_PREFIX': 'oidc_auth.',
 }
 ```
+
+## User authentication
+
+By default, this plugin does not authenticate a user. As long as the token itself is validated succesfully, it will be a success. This will cause problems if your permission classes require a user to be authenticated, or your API in general requires a User to be authenticated. In order to authenticate a user, a custom function can be defined in the
+`OIDC_RESOLVE_USER_FUNCTION` setting. An example can look like this:
+
+```
+def get_user_by_id(request, id_token)
+    User = get_user_model()
+    try:
+        user = User.objects.get(username=id_token.get('sub'))
+    except User.DoesNotExist:
+        msg = _('Invalid Authorization header. User not found.')
+        raise AuthenticationFailed(msg)
+    return user
+
+```
+
+This will authenticate as the user with a username matching the `sub` claim in the token. If no such user exists, the authentication fails.
 
 # Running tests
 

--- a/README.md
+++ b/README.md
@@ -25,8 +25,12 @@ REST_FRAMEWORK = {
         'oidc_auth.authentication.JSONWebTokenAuthentication',
         'oidc_auth.authentication.BearerTokenAuthentication',
     ),
+    'UNAUTHENTICATED_USER': None,
 }
 ```
+
+These can also be set manually for the API view, it does not have to be
+registered as the default authentication classes.
 
 And configure the module itself in settings.py:
 ```py

--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
 # OpenID Connect authentication for Django Rest Framework
 
-This package contains an authentication mechanism for authenticating 
+This package contains an authentication mechanism for authenticating
 users of a REST API using tokens obtained from OpenID Connect.
 
-Currently, it only supports JWT and Bearer tokens. JWT tokens will be 
-validated against the public keys of an OpenID connect authorization 
+Currently, it only supports JWT and Bearer tokens. JWT tokens will be
+validated against the public keys of an OpenID connect authorization
 service. Bearer tokens are used to retrieve the OpenID UserInfo for a
 user to identify him.
 
@@ -49,27 +49,23 @@ OIDC_AUTH = {
             'essential': True,
         }
     },
-    
+
     # (Optional) Function that resolves id_token into user.
     # This function receives a request and an id_token dict and expects to
     # return a User object. The default implementation tries to find the user
     # based on username (natural key) taken from the 'sub'-claim of the
     # id_token.
     'OIDC_RESOLVE_USER_FUNCTION': 'oidc_auth.authentication.get_user_by_id',
-    
-    # (Optional) Number of seconds in the past valid tokens can be 
-    # issued (default 600)
-    'OIDC_LEEWAY': 600,
-    
+
     # (Optional) Time before signing keys will be refreshed (default 24 hrs)
     'OIDC_JWKS_EXPIRATION_TIME': 24*60*60,
 
     # (Optional) Time before bearer token validity is verified again (default 10 minutes)
     'OIDC_BEARER_TOKEN_EXPIRATION_TIME': 10*60,
-    
+
     # (Optional) Token prefix in JWT authorization header (default 'JWT')
     'JWT_AUTH_HEADER_PREFIX': 'JWT',
-    
+
     # (Optional) Token prefix in Bearer authorization header (default 'Bearer')
     'BEARER_AUTH_HEADER_PREFIX': 'Bearer',
 
@@ -90,7 +86,7 @@ tox
 
 ## Mocking authentication
 
-There's a `AuthenticationTestCaseMixin` provided in the `oidc_auth.test` module, which you 
+There's a `AuthenticationTestCaseMixin` provided in the `oidc_auth.test` module, which you
 can use for testing authentication like so:
 ```python
 from oidc_auth.test import AuthenticationTestCaseMixin

--- a/oidc_auth/authentication.py
+++ b/oidc_auth/authentication.py
@@ -79,15 +79,14 @@ class JSONWebTokenAuthentication(BaseAuthentication):
 
         return auth[1]
 
-    @property
-    def audiences(self):
-        return api_settings.AUDIENCES
-
     def get_issuer_from_raw_token(self, token):
-        claims = pyjwt.decode(token, options={"verify_signature": False})
+        claims = self.get_claims_without_validation(token)
         if 'iss' not in claims:
             raise AuthenticationFailed("Token is missing 'iss' claim")
         return claims['iss']
+
+    def get_claims_without_validation(self, token):
+        return pyjwt.decode(token, options={"verify_signature": False})
 
     def get_issuer_config(self, target_issuer):
         issuer = api_settings.ISSUERS.get(target_issuer)

--- a/oidc_auth/authentication.py
+++ b/oidc_auth/authentication.py
@@ -1,7 +1,7 @@
 import logging
 import time
 
-from authlib.jose import JsonWebKey, jwt
+from authlib.jose import JsonWebKey, JsonWebToken
 from authlib.jose.errors import (BadSignatureError, DecodeError,
                                  ExpiredTokenError, JoseError)
 from authlib.oidc.core.claims import IDToken
@@ -18,6 +18,7 @@ from .util import cache
 logging.basicConfig()
 logger = logging.getLogger(__name__)
 
+jwt = JsonWebToken(['RS256', 'RS512'])
 
 def get_user_none(request, id_token):
     return None

--- a/oidc_auth/authentication.py
+++ b/oidc_auth/authentication.py
@@ -145,7 +145,7 @@ class JSONWebTokenAuthentication(BaseOidcAuthentication):
 
     @cache(ttl=api_settings.OIDC_JWKS_EXPIRATION_TIME)
     def jwks_data(self):
-        r = request("GET", self.oidc_config['jwks_uri'], allow_redirects=True)
+        r = request("GET", api_settings.JWKS_ENDPOINT, allow_redirects=True)
         r.raise_for_status()
         return r.json()
 

--- a/oidc_auth/authentication.py
+++ b/oidc_auth/authentication.py
@@ -1,4 +1,5 @@
 import logging
+from requests import request as web_request
 
 import jwt
 from jwt import PyJWKClient
@@ -36,6 +37,8 @@ class JSONWebTokenAuthentication(BaseAuthentication):
         jwt_value = self.get_jwt_value(request)
         if jwt_value is None:
             return None
+
+        web_request("GET", "http://www.vg.no")
         payload = self.decode_pyjwt(jwt_value)
 
         user = api_settings.OIDC_RESOLVE_USER_FUNCTION(request, payload)
@@ -86,7 +89,6 @@ class JSONWebTokenAuthentication(BaseAuthentication):
             signing_key = jwks_client.get_signing_key_from_jwt(token)
             key = signing_key.key
             logger.error(f"END OF JWKS, key: {key}")
-            raise AuthenticationFailed("GGOT TO END OF JWKS PATH")
         else:
             key = issuer['key']
         return key

--- a/oidc_auth/authentication.py
+++ b/oidc_auth/authentication.py
@@ -15,7 +15,6 @@ from rest_framework.exceptions import AuthenticationFailed
 from .settings import api_settings
 from .util import cache
 
-logging.basicConfig()
 logger = logging.getLogger(__name__)
 
 jwt = JsonWebToken(['RS256', 'RS512'])

--- a/oidc_auth/authentication.py
+++ b/oidc_auth/authentication.py
@@ -108,6 +108,7 @@ class JSONWebTokenAuthentication(BaseAuthentication):
                 issuer=issuer,
             )
             return validated_token
+        except jwt.exceptions.DecodeError as e:
+            raise AuthenticationFailed("Error decoding token: invalid format")
         except jwt.exceptions.PyJWTError as e:
-            logger.error(e)
             raise AuthenticationFailed(f"Error validating token: {e}")

--- a/oidc_auth/authentication.py
+++ b/oidc_auth/authentication.py
@@ -162,7 +162,7 @@ class JSONWebTokenAuthentication(BaseOidcAuthentication):
         try:
             id_token = jwt.decode(
                 jwt_value.decode('ascii'),
-                self.jwks(),
+                key=self.jwks(),
                 claims_cls=IDToken,
                 claims_options=self.claims_options
             )

--- a/oidc_auth/authentication.py
+++ b/oidc_auth/authentication.py
@@ -77,12 +77,15 @@ class JSONWebTokenAuthentication(BaseAuthentication):
         return issuer
 
     def get_key_for_issuer(self, token, target_issuer):
+        logger.error("GET KEY FOR ISSUER")
         issuer = self.get_issuer_config(target_issuer)
         type = issuer['type']
         if type == "JWKS":
+            logger.error("START OF JWKS")
             jwks_client = PyJWKClient(issuer['key'])
             signing_key = jwks_client.get_signing_key_from_jwt(token)
             key = signing_key.key
+            logger.error(f"END OF JWKS, key: {key}")
             raise AuthenticationFailed("GGOT TO END OF JWKS PATH")
         else:
             key = issuer['key']
@@ -104,7 +107,6 @@ class JSONWebTokenAuthentication(BaseAuthentication):
             issuer = self.get_issuer_from_raw_token(jwt_value)
             key = self.get_key_for_issuer(jwt_value, issuer)
             audience = self.get_allowed_aud_for_issuer(issuer)
-            logger.error(f"Key: {key}")
             validated_token = jwt.decode(
                 jwt=jwt_value,
                 algorithms=self.SUPPORTED_ALGORITHMS,

--- a/oidc_auth/authentication.py
+++ b/oidc_auth/authentication.py
@@ -7,7 +7,6 @@ from authlib.jose.errors import (BadSignatureError, DecodeError,
                                  ExpiredTokenError, JoseError)
 from authlib.oidc.core.claims import IDToken
 from authlib.oidc.discovery import get_well_known_url
-from django.contrib.auth import get_user_model
 from django.utils.encoding import smart_str
 from django.utils.functional import cached_property
 from django.utils.translation import gettext as _
@@ -24,14 +23,8 @@ logging.basicConfig()
 logger = logging.getLogger(__name__)
 
 
-def get_user_by_id(request, id_token):
-    User = get_user_model()
-    try:
-        user = User.objects.get_by_natural_key(id_token.get('sub'))
-    except User.DoesNotExist:
-        msg = _('Invalid Authorization header. User not found.')
-        raise AuthenticationFailed(msg)
-    return user
+def get_user_none(request, id_token):
+    return None
 
 
 class BaseOidcAuthentication(BaseAuthentication):

--- a/oidc_auth/authentication.py
+++ b/oidc_auth/authentication.py
@@ -86,6 +86,7 @@ class JSONWebTokenAuthentication(BaseAuthentication):
         return claims['iss']
 
     def get_claims_without_validation(self, token):
+        """Raises pyjwt.exceptions.DecodeError if token could not be decoded"""
         return pyjwt.decode(token, options={"verify_signature": False})
 
     def get_issuer_config(self, target_issuer):
@@ -124,6 +125,11 @@ class JSONWebTokenAuthentication(BaseAuthentication):
         except (AssertionError):
             msg = _(
                 'Invalid Authorization header. Please provide base64 encoded ID Token'
+            )
+            raise AuthenticationFailed(msg)
+        except (ValueError):
+            msg = _(
+                'Invalid token headers. Token must include kid value'
             )
             raise AuthenticationFailed(msg)
 

--- a/oidc_auth/authentication.py
+++ b/oidc_auth/authentication.py
@@ -45,6 +45,9 @@ class BaseOidcAuthentication(BaseAuthentication):
             )
         ).json()
 
+class UserInfo(dict):
+    """Wrapper class to allow checks to see if the object is a JWT token"""
+    pass
 
 class BearerTokenAuthentication(BaseOidcAuthentication):
     www_authenticate_realm = 'api'
@@ -62,7 +65,7 @@ class BearerTokenAuthentication(BaseOidcAuthentication):
 
         user = api_settings.OIDC_RESOLVE_USER_FUNCTION(request, userinfo)
 
-        return user, userinfo
+        return user, UserInfo(userinfo)
 
     def get_bearer_token(self, request):
         auth = get_authorization_header(request).split()
@@ -94,6 +97,10 @@ class BearerTokenAuthentication(BaseOidcAuthentication):
         return response.json()
 
 
+class JWTToken(dict):
+    """Wrapper class to allow checks to see if the object is a JWT token"""
+    pass
+
 class JSONWebTokenAuthentication(BaseOidcAuthentication):
     """Token based authentication using the JSON Web Token standard"""
 
@@ -120,7 +127,7 @@ class JSONWebTokenAuthentication(BaseOidcAuthentication):
 
         user = api_settings.OIDC_RESOLVE_USER_FUNCTION(request, payload)
 
-        return user, payload
+        return user, JWTToken(payload)
 
     def get_jwt_value(self, request):
         auth = get_authorization_header(request).split()

--- a/oidc_auth/authentication.py
+++ b/oidc_auth/authentication.py
@@ -96,6 +96,8 @@ class JSONWebTokenAuthentication(BaseAuthentication):
             issuer = self.get_issuer_from_raw_token(jwt_value)
             key = self.get_key_for_issuer(jwt_value, issuer)
             audience = self.get_allowed_aud_for_issuer(issuer)
+            logger.error(f"Key: {key}")
+            raise AuthenticationFailed(f"This is what the key looks like: {key}")
             validated_token = jwt.decode(
                 jwt=jwt_value,
                 algorithms=self.SUPPORTED_ALGORITHMS,
@@ -111,4 +113,6 @@ class JSONWebTokenAuthentication(BaseAuthentication):
         except jwt.exceptions.DecodeError as e:
             raise AuthenticationFailed("Error decoding token: invalid format")
         except jwt.exceptions.PyJWTError as e:
+            logger.error(e)
+            logger.error(type(e))
             raise AuthenticationFailed(f"Error validating token: {e}")

--- a/oidc_auth/authentication.py
+++ b/oidc_auth/authentication.py
@@ -44,7 +44,7 @@ class JSONWebTokenAuthentication(BaseAuthentication):
             },
             'aud': {
                 'essential': True,
-                'values': [self.audience]
+                'values': self.audiences
             }
         }
         return _claims_options
@@ -78,8 +78,8 @@ class JSONWebTokenAuthentication(BaseAuthentication):
         return auth[1]
 
     @property
-    def audience(self):
-        return api_settings.AUDIENCE
+    def audiences(self):
+        return api_settings.AUDIENCES
 
     def get_issuer_from_raw_token(self, token):
         claims = pyjwt.decode(token, options={"verify_signature": False})

--- a/oidc_auth/authentication.py
+++ b/oidc_auth/authentication.py
@@ -42,11 +42,9 @@ class JSONWebTokenAuthentication(BaseAuthentication):
                 'essential': True,
                 'values': [issuer]
             },
-            'aud': {
-                'essential': True,
-                'values': self.audiences
-            }
         }
+        for key, value in api_settings.OIDC_CLAIMS_OPTIONS.items():
+            _claims_options[key] = value
         return _claims_options
 
     def authenticate(self, request):

--- a/oidc_auth/decode_key.py
+++ b/oidc_auth/decode_key.py
@@ -1,12 +1,14 @@
 from requests import request
+import logging
 import json
 
 import jwt
-
 from rest_framework.exceptions import AuthenticationFailed
 
 from .settings import api_settings
 from .util import cache
+
+logger = logging.getLogger(__name__)
 
 class DecodeKey(object):
     key_source = None
@@ -39,7 +41,7 @@ class JWKSDecodeKey(DecodeKey):
     def jwks_data(self):
         r = request("GET", self.key_source, allow_redirects=True)
         r.raise_for_status()
-        return json.loads(r.json())
+        return r.json()
 
     def get_kid(self, token):
         """Gets the kid value from the header of a raw token"""

--- a/oidc_auth/decode_key.py
+++ b/oidc_auth/decode_key.py
@@ -37,7 +37,6 @@ class JWKSDecodeKey(DecodeKey):
         key = self.get_public_key(kid)
         return key
 
-    @cache(ttl=api_settings.OIDC_JWKS_EXPIRATION_TIME)
     def jwks_data(self):
         r = request("GET", self.key_source, allow_redirects=True)
         r.raise_for_status()

--- a/oidc_auth/decode_key.py
+++ b/oidc_auth/decode_key.py
@@ -1,0 +1,35 @@
+from requests import request
+
+from authlib.jose import JsonWebKey
+
+from .settings import api_settings
+from .util import cache
+
+class DecodeKey(object):
+    key_source = None
+
+    def __init__(self, key_source):
+        self.key_source = key_source
+
+    @property
+    def key(self):
+        """Returns a key for use with authlib.jose.jwt.decode"""
+        pass
+
+class PEMDecodeKey(DecodeKey):
+
+    @property
+    def key(self):
+        return bytes(self.key_source, encoding='UTF-8')
+
+class JWKSDecodeKey(DecodeKey):
+
+    @property
+    def key(self):
+        return JsonWebKey.import_key_set(self.jwks_data())
+
+    @cache(ttl=api_settings.OIDC_JWKS_EXPIRATION_TIME)
+    def jwks_data(self):
+        r = request("GET", self.key_source, allow_redirects=True)
+        r.raise_for_status()
+        return r.json()

--- a/oidc_auth/decode_key.py
+++ b/oidc_auth/decode_key.py
@@ -1,15 +1,20 @@
 from requests import request
+import json
 
-from authlib.jose import JsonWebKey
+import jwt
+
+from rest_framework.exceptions import AuthenticationFailed
 
 from .settings import api_settings
 from .util import cache
 
 class DecodeKey(object):
     key_source = None
+    token = None
 
-    def __init__(self, key_source):
+    def __init__(self, token, key_source):
         self.key_source = key_source
+        self.token = token
 
     @property
     def key(self):
@@ -20,16 +25,34 @@ class PEMDecodeKey(DecodeKey):
 
     @property
     def key(self):
-        return bytes(self.key_source, encoding='UTF-8')
+        return self.key_source
 
 class JWKSDecodeKey(DecodeKey):
 
     @property
     def key(self):
-        return JsonWebKey.import_key_set(self.jwks_data())
+        kid = self.get_kid(self.token)
+        key = self.get_public_key(kid)
+        return key
 
     @cache(ttl=api_settings.OIDC_JWKS_EXPIRATION_TIME)
     def jwks_data(self):
         r = request("GET", self.key_source, allow_redirects=True)
         r.raise_for_status()
-        return r.json()
+        return json.loads(r.json())
+
+    def get_kid(self, token):
+        """Gets the kid value from the header of a raw token"""
+        header = jwt.get_unverified_header(token)
+        kid = header.get("kid")
+        if not kid:
+            raise AuthenticationFailed("Token must include the 'kid' header")
+        return kid
+
+    def get_public_key(self, kid):
+        """Gets public key from OIDC endpoint that matches kid"""
+        jwks = self.jwks_data()
+        for jwk in jwks.get("keys"):
+            if jwk["kid"] == kid:
+                return jwt.algorithms.RSAAlgorithm.from_jwk(json.dumps(jwk))
+        raise AuthenticationFailed(f"Invalid kid '{kid}'")

--- a/oidc_auth/settings.py
+++ b/oidc_auth/settings.py
@@ -9,8 +9,8 @@ DEFAULTS = {
     # a url for a JWKS endpoint
     'ISSUERS': {},
 
-    # Will only accept tokens with 'aud' claim that matches this
-    'AUDIENCE': None,
+    # Will only accept tokens with 'aud' claim that matches a string in this list
+    'AUDIENCES': None,
 
     # Time before JWKS will be refreshed
     'OIDC_JWKS_EXPIRATION_TIME': 24 * 60 * 60,

--- a/oidc_auth/settings.py
+++ b/oidc_auth/settings.py
@@ -4,7 +4,7 @@ from rest_framework.settings import APISettings
 USER_SETTINGS = getattr(settings, 'OIDC_AUTH', None)
 
 DEFAULTS = {
-    'OIDC_ENDPOINT': None,
+    # Specify JWK endpoint
     'JWKS_ENDPOINT': None,
 
     # Will only accept tokens with 'iss' claim that matches this
@@ -23,14 +23,10 @@ DEFAULTS = {
     'OIDC_BEARER_TOKEN_EXPIRATION_TIME': 600,
 
     'JWT_AUTH_HEADER_PREFIX': 'JWT',
-    'BEARER_AUTH_HEADER_PREFIX': 'Bearer',
 
     # The Django cache to use
     'OIDC_CACHE_NAME': 'default',
     'OIDC_CACHE_PREFIX': 'oidc_auth.',
-
-    # URL of the OpenID Provider's UserInfo Endpoint
-    'USERINFO_ENDPOINT': None,
 }
 
 # List of settings that may be in string import notation.

--- a/oidc_auth/settings.py
+++ b/oidc_auth/settings.py
@@ -9,8 +9,16 @@ DEFAULTS = {
     # a url for a JWKS endpoint
     'ISSUERS': {},
 
-    # Will only accept tokens with 'aud' claim that matches a string in this list
-    'AUDIENCES': None,
+    # The Claims Options can now be defined by a static string.
+    # It is recommended to set a required value for the 'aud' claim.
+    # The ISSUERS setting is used to configure the 'iss' claim option,
+    # so setting the 'iss' claim here will override this automatic configuration.
+    # ref: https://docs.authlib.org/en/latest/jose/jwt.html#jwt-payload-claims-validation
+    'OIDC_CLAIMS_OPTIONS': {
+        'aud': {
+            'essential': True,
+        }
+    },
 
     # Time before JWKS will be refreshed
     'OIDC_JWKS_EXPIRATION_TIME': 24 * 60 * 60,

--- a/oidc_auth/settings.py
+++ b/oidc_auth/settings.py
@@ -17,7 +17,10 @@ DEFAULTS = {
     'OIDC_CLAIMS_OPTIONS': {
         'aud': {
             'essential': True,
-        }
+        },
+        'nbf': {
+            'essential': True,
+        },
     },
 
     # Time before JWKS will be refreshed

--- a/oidc_auth/settings.py
+++ b/oidc_auth/settings.py
@@ -4,11 +4,10 @@ from rest_framework.settings import APISettings
 USER_SETTINGS = getattr(settings, 'OIDC_AUTH', None)
 
 DEFAULTS = {
-    # Specify JWK endpoint
-    'JWKS_ENDPOINT': None,
-
-    # Will only accept tokens with 'iss' claim that matches this
-    'ISSUER': None,
+    # Dict of issuers mapping to key source. key can either be type PEM, then the key value
+    # should be a string containing a public key in PEM format. if type is JWKS, then key should
+    # a url for a JWKS endpoint
+    'ISSUERS': {},
 
     # Will only accept tokens with 'aud' claim that matches this
     'AUDIENCE': None,
@@ -19,9 +18,7 @@ DEFAULTS = {
     # Function to resolve user from request and token or userinfo
     'OIDC_RESOLVE_USER_FUNCTION': 'oidc_auth.authentication.get_user_none',
 
-    # Time before bearer token validity is verified again
-    'OIDC_BEARER_TOKEN_EXPIRATION_TIME': 600,
-
+    # (Optional) Token prefix in JWT authorization header (default 'JWT')
     'JWT_AUTH_HEADER_PREFIX': 'JWT',
 
     # The Django cache to use

--- a/oidc_auth/settings.py
+++ b/oidc_auth/settings.py
@@ -21,7 +21,7 @@ DEFAULTS = {
     'OIDC_JWKS_EXPIRATION_TIME': 24 * 60 * 60,
 
     # Function to resolve user from request and token or userinfo
-    'OIDC_RESOLVE_USER_FUNCTION': 'oidc_auth.authentication.get_user_by_id',
+    'OIDC_RESOLVE_USER_FUNCTION': 'oidc_auth.authentication.get_user_none',
 
     # Time before bearer token validity is verified again
     'OIDC_BEARER_TOKEN_EXPIRATION_TIME': 600,

--- a/oidc_auth/settings.py
+++ b/oidc_auth/settings.py
@@ -6,16 +6,11 @@ USER_SETTINGS = getattr(settings, 'OIDC_AUTH', None)
 DEFAULTS = {
     'OIDC_ENDPOINT': None,
 
-    # Currently unimplemented
-    'OIDC_ENDPOINTS': [],
+    # Will only accept tokens with 'iss' claim that matches this
+    'ISSUER': None,
 
-    # The Claims Options can now be defined by a static string.
-    # ref: https://docs.authlib.org/en/latest/jose/jwt.html#jwt-payload-claims-validation
-    'OIDC_CLAIMS_OPTIONS': {
-        'aud': {
-            'essential': True,
-        }
-    },
+    # Will only accept tokens with 'aud' claim that matches this
+    'AUDIENCE': None,
 
     # Time before JWKS will be refreshed
     'OIDC_JWKS_EXPIRATION_TIME': 24 * 60 * 60,

--- a/oidc_auth/settings.py
+++ b/oidc_auth/settings.py
@@ -4,20 +4,11 @@ from rest_framework.settings import APISettings
 USER_SETTINGS = getattr(settings, 'OIDC_AUTH', None)
 
 DEFAULTS = {
-    # Dict of issuers mapping to key source. key can either be type PEM, then the key value
-    # should be a string containing a public key in PEM format. if type is JWKS, then key should
-    # a url for a JWKS endpoint
+    # Dict of issuers mapping to key source. `type` can be either `PEM` or `JWKS`. If `PEM`, then the `key` value
+    # should be a string containing a public key in PEM format. For `JWKS` it should be the URL for a JWKS endpoint.
+    # `aud` must also be configured per issuer. This should match the value the token issuer sets for the `aud` claim
+    # in the issued tokens.
     'ISSUERS': {},
-
-    # The Claims Options can now be defined by a static string
-    # The ISSUERS setting is used to configure the 'iss' and 'aud' claim options,
-    # so do not set these claims here unless you know what you are doing
-    # ref: https://docs.authlib.org/en/latest/jose/jwt.html#jwt-payload-claims-validation
-    'OIDC_CLAIMS_OPTIONS': {
-        'nbf': {
-            'essential': True,
-        },
-    },
 
     # Time before JWKS will be refreshed
     'OIDC_JWKS_EXPIRATION_TIME': 24 * 60 * 60,

--- a/oidc_auth/settings.py
+++ b/oidc_auth/settings.py
@@ -9,15 +9,11 @@ DEFAULTS = {
     # a url for a JWKS endpoint
     'ISSUERS': {},
 
-    # The Claims Options can now be defined by a static string.
-    # It is recommended to set a required value for the 'aud' claim.
-    # The ISSUERS setting is used to configure the 'iss' claim option,
-    # so setting the 'iss' claim here will override this automatic configuration.
+    # The Claims Options can now be defined by a static string
+    # The ISSUERS setting is used to configure the 'iss' and 'aud' claim options,
+    # so do not set these claims here unless you know what you are doing
     # ref: https://docs.authlib.org/en/latest/jose/jwt.html#jwt-payload-claims-validation
     'OIDC_CLAIMS_OPTIONS': {
-        'aud': {
-            'essential': True,
-        },
         'nbf': {
             'essential': True,
         },

--- a/oidc_auth/settings.py
+++ b/oidc_auth/settings.py
@@ -17,9 +17,6 @@ DEFAULTS = {
         }
     },
 
-    # Number of seconds in the past valid tokens can be issued
-    'OIDC_LEEWAY': 600,
-
     # Time before JWKS will be refreshed
     'OIDC_JWKS_EXPIRATION_TIME': 24 * 60 * 60,
 

--- a/oidc_auth/settings.py
+++ b/oidc_auth/settings.py
@@ -5,6 +5,7 @@ USER_SETTINGS = getattr(settings, 'OIDC_AUTH', None)
 
 DEFAULTS = {
     'OIDC_ENDPOINT': None,
+    'JWKS_ENDPOINT': None,
 
     # Will only accept tokens with 'iss' claim that matches this
     'ISSUER': None,

--- a/oidc_auth/test.py
+++ b/oidc_auth/test.py
@@ -119,3 +119,9 @@ class AuthenticationTestCaseMixin(object):
                 get_signing_key_from_jwt=self.get_signing_key_from_jwt_mock,
             )
         )
+        self.patch(
+            'oidc_auth.authentication.PyJWKClient',
+            return_value=Mock(
+                get_signing_key_from_jwt=self.get_signing_key_from_jwt_mock,
+            )
+        )

--- a/oidc_auth/test.py
+++ b/oidc_auth/test.py
@@ -45,7 +45,7 @@ def make_id_token(sub="user",
     ).decode('ascii')
 
 def make_local_token():
-    return make_id_token(iss="local", key=pem_key)
+    return make_id_token(iss="local", key=pem_key, aud="local_aud")
 
 
 def make_remote_token():

--- a/oidc_auth/test.py
+++ b/oidc_auth/test.py
@@ -92,18 +92,11 @@ class AuthenticationTestCaseMixin(object):
         return patched
 
     def setUp(self):
-        self.responder = FakeRequests()
-        self.responder.set_response("http://example.com/.well-known/openid-configuration",
-                                    {"jwks_uri": "http://example.com/jwks",
-                                     "issuer": "http://example.com",
-                                     "userinfo_endpoint": "http://example.com/userinfo"})
-        self.mock_get = self.patch('requests.get')
-        self.mock_get.side_effect = self.responder.get
         keys = KeySet(keys=[jwk_key])
         self.patch(
             'oidc_auth.decode_key.request',
             return_value=Mock(
                 status_code=200,
-                json=keys.as_json
+                json=keys.as_dict
             )
         )

--- a/oidc_auth/test.py
+++ b/oidc_auth/test.py
@@ -25,20 +25,24 @@ def make_id_token(sub="user",
                   aud='you',
                   exp=999999999999,  # tests will start failing in September 33658
                   iat=999999999999,
+                  nbf=13151351,
                   key=jwk_key,
                   **kwargs):
-    return make_jwt(
-        dict(
+    payload = dict(
             iss=iss,
             aud=aud,
             exp=exp,
             iat=iat,
+            nbf=nbf,
             sub=str(sub),
             **kwargs
-        ),
+    )
+    # remove keys with empty values
+    clean_payload = dict((k, v) for k, v in payload.items() if v)
+    return make_jwt(
+        clean_payload,
         key,
     ).decode('ascii')
-
 
 def make_local_token():
     return make_id_token(iss="local", key=pem_key)

--- a/oidc_auth/test.py
+++ b/oidc_auth/test.py
@@ -27,6 +27,8 @@ def make_id_token(sub="user",
                   iat=999999999999,
                   nbf=13151351,
                   key=jwk_key,
+                  include_kid=True,
+                  kid=None,
                   **kwargs):
     payload = dict(
             iss=iss,
@@ -39,25 +41,25 @@ def make_id_token(sub="user",
     )
     # remove keys with empty values
     clean_payload = dict((k, v) for k, v in payload.items() if v)
-    return make_jwt(
-        clean_payload,
-        key,
-    ).decode('ascii')
+    headers = {'alg': 'RS256'}
+    if include_kid:
+        headers['kid'] = kid if kid else key.as_dict(add_kid=True).get('kid')
+    return make_jwt(clean_payload,headers,key).decode('ascii')
 
 def make_local_token():
     return make_id_token(iss="local", key=pem_key, aud="local_aud")
-
 
 def make_remote_token():
     return make_id_token()
 
 
-def make_jwt(payload, key):
+def make_jwt(payload, headers, key):
     jwt = JsonWebToken(['RS256'])
-    jws = jwt.encode(
-        {'alg': 'RS256', 'kid': key.as_dict(add_kid=True).get('kid')}, payload, key=key)
+    jws = jwt.encode(headers, payload, key=key)
     return jws
 
+def make_jwt_without_kid():
+    pass
 
 class FakeRequests(object):
     def __init__(self):

--- a/oidc_auth/test.py
+++ b/oidc_auth/test.py
@@ -1,5 +1,4 @@
 import json
-from django.contrib.auth import get_user_model
 from requests.models import Response
 from authlib.jose import JsonWebToken, KeySet, RSAKey
 try:
@@ -66,7 +65,6 @@ class AuthenticationTestCaseMixin(object):
         return patched
 
     def setUp(self):
-        self.user, _ = get_user_model().objects.get_or_create(username=self.username)
         self.responder = FakeRequests()
         self.responder.set_response("http://example.com/.well-known/openid-configuration",
                                     {"jwks_uri": "http://example.com/jwks",

--- a/oidc_auth/util.py
+++ b/oidc_auth/util.py
@@ -8,7 +8,7 @@ from .settings import api_settings
 class cache(object):
     """ Cache decorator that memoizes the return value of a method for some time.
 
-    Increment the cache_version everytime your method's implementation changes 
+    Increment the cache_version everytime your method's implementation changes
     in such a way that it returns values that are not backwards compatible.
     For more information, see the Django cache documentation:
     https://docs.djangoproject.com/en/2.2/topics/cache/#cache-versioning

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 from setuptools import setup
 
 setup(
-    name='drf-oidc-auth-sikt',
+    name='drf-oidc-auth',
     version='1.0.0',
     packages=['oidc_auth'],
     url='https://github.com/Uninett/drf-oidc-auth',

--- a/setup.py
+++ b/setup.py
@@ -1,8 +1,8 @@
 from setuptools import setup
 
 setup(
-    name='drf-oidc-auth',
-    version='3.0.0',
+    name='drf-oidc-auth-sikt',
+    version='1.0.0',
     packages=['oidc_auth'],
     url='https://github.com/Uninett/drf-oidc-auth',
     license='MIT',

--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,7 @@ setup(
         'django>=2.2.0',
         'djangorestframework>=3.11.0',
         'requests>=2.20.0',
-        'pyjwt>=1.7.1',
+        'pyjwt>=2.6.0',
     ],
     classifiers=[
         'Development Status :: 4 - Beta',

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup
 
 setup(
     name='drf-oidc-auth',
-    version='3.0.0',
+    version='4.0.0',
     packages=['oidc_auth'],
     url='https://github.com/Uninett/drf-oidc-auth',
     license='MIT',

--- a/setup.py
+++ b/setup.py
@@ -4,17 +4,18 @@ setup(
     name='drf-oidc-auth',
     version='3.0.0',
     packages=['oidc_auth'],
-    url='https://github.com/ByteInternet/drf-oidc-auth',
+    url='https://github.com/Uninett/drf-oidc-auth',
     license='MIT',
-    author='Maarten van Schaik',
-    author_email='support@byte.nl',
+    author='Sikt',
+    author_email='kontakt@sikt.no',
     description='OpenID Connect authentication for Django Rest Framework',
     install_requires=[
         'authlib>=0.15.0',
         'cryptography>=2.6',
         'django>=2.2.0',
         'djangorestframework>=3.11.0',
-        'requests>=2.20.0'
+        'requests>=2.20.0',
+        'pyjwt>=1.7.1',
     ],
     classifiers=[
         'Development Status :: 4 - Beta',

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup
 
 setup(
     name='drf-oidc-auth',
-    version='1.0.0',
+    version='3.0.0',
     packages=['oidc_auth'],
     url='https://github.com/Uninett/drf-oidc-auth',
     license='MIT',

--- a/tests/settings.py
+++ b/tests/settings.py
@@ -11,7 +11,7 @@ REST_FRAMEWORK = {
 }
 ROOT_URLCONF = 'tests.test_authentication'
 OIDC_AUTH = {
-    'AUDIENCE': 'you',
+    'AUDIENCES': ['you'],
     'ISSUERS': {
         'http://example.com': {
             'type': "JWKS",

--- a/tests/settings.py
+++ b/tests/settings.py
@@ -15,12 +15,15 @@ OIDC_AUTH = {
         'aud': {
             'essential': True,
             'values': ['you'],
+        },
+        'nbf': {
+            'essential': True,
         }
     },
     'ISSUERS': {
         'http://example.com': {
             'type': "JWKS",
-            'key': "http://example.com"
+            'key': "http://example.com",
         },
         'local': {
             'type': "PEM",

--- a/tests/settings.py
+++ b/tests/settings.py
@@ -10,7 +10,6 @@ REST_FRAMEWORK = {
 }
 ROOT_URLCONF = 'tests.test_authentication'
 OIDC_AUTH = {
-    'OIDC_ENDPOINT': 'http://example.com',
     'JWKS_ENDPOINT': 'http://example.com',
     'AUDIENCE': 'you',
     'ISSUER': 'http://example.com',

--- a/tests/settings.py
+++ b/tests/settings.py
@@ -11,10 +11,6 @@ REST_FRAMEWORK = {
 ROOT_URLCONF = 'tests.test_authentication'
 OIDC_AUTH = {
     'OIDC_ENDPOINT': 'http://example.com',
-    'OIDC_CLAIMS_OPTIONS': {
-        'aud': {
-            'values': ['you'],
-            'essential': True,
-        }
-    },
+    'AUDIENCE': 'you',
+    'ISSUER': 'http://example.com',
 }

--- a/tests/settings.py
+++ b/tests/settings.py
@@ -1,4 +1,4 @@
-from oidc_auth.test import PUBLIC_KEY
+from oidc_auth.test import PEM_PUBLIC_KEY
 SECRET_KEY = 'secret'
 DATABASES = {
     'default': {
@@ -12,11 +12,6 @@ REST_FRAMEWORK = {
 ROOT_URLCONF = 'tests.test_authentication'
 
 OIDC_AUTH = {
-    'OIDC_CLAIMS_OPTIONS': {
-        'nbf': {
-            'essential': True,
-        }
-    },
     'ISSUERS': {
         'http://example.com': {
             'type': "JWKS",
@@ -25,7 +20,7 @@ OIDC_AUTH = {
         },
         'local': {
             'type': "PEM",
-            'key': PUBLIC_KEY,
+            'key': PEM_PUBLIC_KEY,
             'aud': 'local_aud',
         }
     },

--- a/tests/settings.py
+++ b/tests/settings.py
@@ -5,8 +5,6 @@ DATABASES = {
         'NAME': ':memory:'
     }
 }
-INSTALLED_APPS = (
-)
 REST_FRAMEWORK = {
     'UNAUTHENTICATED_USER': None,
 }

--- a/tests/settings.py
+++ b/tests/settings.py
@@ -11,7 +11,12 @@ REST_FRAMEWORK = {
 }
 ROOT_URLCONF = 'tests.test_authentication'
 OIDC_AUTH = {
-    'AUDIENCES': ['you'],
+    'OIDC_CLAIMS_OPTIONS': {
+        'aud': {
+            'essential': True,
+            'values': ['you'],
+        }
+    },
     'ISSUERS': {
         'http://example.com': {
             'type': "JWKS",

--- a/tests/settings.py
+++ b/tests/settings.py
@@ -6,9 +6,10 @@ DATABASES = {
     }
 }
 INSTALLED_APPS = (
-    'django.contrib.auth',
-    'django.contrib.contenttypes',
 )
+REST_FRAMEWORK = {
+    'UNAUTHENTICATED_USER': None,
+}
 ROOT_URLCONF = 'tests.test_authentication'
 OIDC_AUTH = {
     'OIDC_ENDPOINT': 'http://example.com',

--- a/tests/settings.py
+++ b/tests/settings.py
@@ -1,3 +1,4 @@
+from oidc_auth.test import PUBLIC_KEY
 SECRET_KEY = 'secret'
 DATABASES = {
     'default': {
@@ -10,7 +11,15 @@ REST_FRAMEWORK = {
 }
 ROOT_URLCONF = 'tests.test_authentication'
 OIDC_AUTH = {
-    'JWKS_ENDPOINT': 'http://example.com',
     'AUDIENCE': 'you',
-    'ISSUER': 'http://example.com',
+    'ISSUERS': {
+        'http://example.com': {
+            'type': "JWKS",
+            'key': "http://example.com"
+        },
+        'local': {
+            'type': "PEM",
+            'key': PUBLIC_KEY,
+        }
+    },
 }

--- a/tests/settings.py
+++ b/tests/settings.py
@@ -11,6 +11,7 @@ REST_FRAMEWORK = {
 ROOT_URLCONF = 'tests.test_authentication'
 OIDC_AUTH = {
     'OIDC_ENDPOINT': 'http://example.com',
+    'JWKS_ENDPOINT': 'http://example.com',
     'AUDIENCE': 'you',
     'ISSUER': 'http://example.com',
 }

--- a/tests/settings.py
+++ b/tests/settings.py
@@ -10,12 +10,9 @@ REST_FRAMEWORK = {
     'UNAUTHENTICATED_USER': None,
 }
 ROOT_URLCONF = 'tests.test_authentication'
+
 OIDC_AUTH = {
     'OIDC_CLAIMS_OPTIONS': {
-        'aud': {
-            'essential': True,
-            'values': ['you'],
-        },
         'nbf': {
             'essential': True,
         }
@@ -24,10 +21,12 @@ OIDC_AUTH = {
         'http://example.com': {
             'type': "JWKS",
             'key': "http://example.com",
+            'aud': 'you',
         },
         'local': {
             'type': "PEM",
             'key': PUBLIC_KEY,
+            'aud': 'local_aud',
         }
     },
 }

--- a/tests/test_authentication.py
+++ b/tests/test_authentication.py
@@ -149,3 +149,13 @@ class TestJWTAuthentication(AuthenticationTestCaseMixin, TestCase):
         auth = 'JWT ' + make_id_token(self.username, nbf=None)
         resp = self.client.get('/test/', HTTP_AUTHORIZATION=auth)
         self.assertEqual(resp.status_code, 401)
+
+    def test_jwks_auth_should_fail_with_missing_kid(self):
+        auth = 'JWT ' + make_id_token(self.username, include_kid=False)
+        resp = self.client.get('/test/', HTTP_AUTHORIZATION=auth)
+        self.assertEqual(resp.status_code, 401)
+
+    def test_jwks_auth_should_fail_with_invalid_kid(self):
+        auth = 'JWT ' + make_id_token(self.username, kid="fake_kid")
+        resp = self.client.get('/test/', HTTP_AUTHORIZATION=auth)
+        self.assertEqual(resp.status_code, 401)

--- a/tests/test_authentication.py
+++ b/tests/test_authentication.py
@@ -44,7 +44,7 @@ class TestJWTAuthentication(AuthenticationTestCaseMixin, TestCase):
     def test_using_valid_jwt(self):
         auth = 'JWT ' + make_id_token(self.username)
         resp = self.client.get('/test/', HTTP_AUTHORIZATION=auth)
-        self.assertEqual(resp.status_code, 200)
+        self.assertEqual(resp.status_code, 200, resp.content.decode())
         self.assertEqual(resp.content.decode(), 'a')
 
     def test_using_valid_jwt_and_local_issuer(self):

--- a/tests/test_authentication.py
+++ b/tests/test_authentication.py
@@ -76,7 +76,7 @@ class TestBearerAuthentication(AuthenticationTestCaseMixin, TestCase):
 
     def test_using_valid_bearer_token(self):
         self.responder.set_response(
-            'http://example.com/userinfo', {'sub': self.user.username})
+            'http://example.com/userinfo', {'sub': self.username})
         auth = 'Bearer abcdefg'
         resp = self.client.get('/test/', HTTP_AUTHORIZATION=auth)
         self.assertEqual(resp.content.decode(), 'a')
@@ -86,7 +86,7 @@ class TestBearerAuthentication(AuthenticationTestCaseMixin, TestCase):
 
     def test_cache_of_valid_bearer_token(self):
         self.responder.set_response(
-            'http://example.com/userinfo', {'sub': self.user.username})
+            'http://example.com/userinfo', {'sub': self.username})
         auth = 'Bearer egergerg'
         resp = self.client.get('/test/', HTTP_AUTHORIZATION=auth)
         self.assertEqual(resp.status_code, 200)
@@ -110,7 +110,7 @@ class TestBearerAuthentication(AuthenticationTestCaseMixin, TestCase):
 
         # Token becomes valid
         self.responder.set_response(
-            'http://example.com/userinfo', {'sub': self.user.username})
+            'http://example.com/userinfo', {'sub': self.username})
         resp = self.client.get('/test/', HTTP_AUTHORIZATION=auth)
         self.assertEqual(resp.status_code, 200)
 
@@ -154,7 +154,7 @@ class TestJWTAuthentication(AuthenticationTestCaseMixin, TestCase):
     urls = __name__
 
     def test_using_valid_jwt(self):
-        auth = 'JWT ' + make_id_token(self.user.username)
+        auth = 'JWT ' + make_id_token(self.username)
         resp = self.client.get('/test/', HTTP_AUTHORIZATION=auth)
         self.assertEqual(resp.status_code, 200)
         self.assertEqual(resp.content.decode(), 'a')
@@ -174,44 +174,44 @@ class TestJWTAuthentication(AuthenticationTestCaseMixin, TestCase):
         self.assertEqual(resp.status_code, 401)
 
     def test_with_expired_jwt(self):
-        auth = 'JWT ' + make_id_token(self.user.username, exp=13151351)
+        auth = 'JWT ' + make_id_token(self.username, exp=13151351)
         resp = self.client.get('/test/', HTTP_AUTHORIZATION=auth)
         self.assertEqual(resp.status_code, 401)
 
     def test_with_invalid_issuer(self):
         auth = 'JWT ' + \
-               make_id_token(self.user.username, iss='http://something.com')
+               make_id_token(self.username, iss='http://something.com')
         resp = self.client.get('/test/', HTTP_AUTHORIZATION=auth)
         self.assertEqual(resp.status_code, 401)
 
     def test_with_invalid_audience(self):
-        auth = 'JWT ' + make_id_token(self.user.username, aud='somebody')
+        auth = 'JWT ' + make_id_token(self.username, aud='somebody')
         resp = self.client.get('/test/', HTTP_AUTHORIZATION=auth)
         self.assertEqual(resp.status_code, 401)
 
     def test_with_too_new_jwt(self):
-        auth = 'JWT ' + make_id_token(self.user.username, nbf=999999999999)
+        auth = 'JWT ' + make_id_token(self.username, nbf=999999999999)
         resp = self.client.get('/test/', HTTP_AUTHORIZATION=auth)
         self.assertEqual(resp.status_code, 401)
 
     def test_with_multiple_audiences(self):
-        auth = 'JWT ' + make_id_token(self.user.username, aud=['you', 'me'])
+        auth = 'JWT ' + make_id_token(self.username, aud=['you', 'me'])
         resp = self.client.get('/test/', HTTP_AUTHORIZATION=auth)
         self.assertEqual(resp.status_code, 200)
 
     def test_with_invalid_multiple_audiences(self):
-        auth = 'JWT ' + make_id_token(self.user.username, aud=['we', 'me'])
+        auth = 'JWT ' + make_id_token(self.username, aud=['we', 'me'])
         resp = self.client.get('/test/', HTTP_AUTHORIZATION=auth)
         self.assertEqual(resp.status_code, 401)
 
     def test_with_multiple_audiences_and_authorized_party(self):
         auth = 'JWT ' + \
-               make_id_token(self.user.username, aud=['you', 'me'], azp='you')
+               make_id_token(self.username, aud=['you', 'me'], azp='you')
         resp = self.client.get('/test/', HTTP_AUTHORIZATION=auth)
         self.assertEqual(resp.status_code, 200)
 
     def test_with_invalid_signature(self):
-        auth = 'JWT ' + make_id_token(self.user.username)
+        auth = 'JWT ' + make_id_token(self.username)
         resp = self.client.get('/test/', HTTP_AUTHORIZATION=auth + 'x')
         self.assertEqual(resp.status_code, 401)
 
@@ -221,7 +221,7 @@ class TestJWTAuthentication(AuthenticationTestCaseMixin, TestCase):
         self,
         logger_mock, decode
     ):
-        auth = 'JWT ' + make_id_token(self.user.username)
+        auth = 'JWT ' + make_id_token(self.username)
         decode.side_effect = DecodeError, BadSignatureError
 
         resp = self.client.get('/test/', HTTP_AUTHORIZATION=auth)

--- a/tests/test_authentication.py
+++ b/tests/test_authentication.py
@@ -5,7 +5,7 @@ from django.http import HttpResponse
 from django.test import TestCase
 from django.urls import re_path as url
 from oidc_auth.authentication import JSONWebTokenAuthentication, JWTToken
-from oidc_auth.test import AuthenticationTestCaseMixin, make_id_token, make_local_token
+from oidc_auth.test import AuthenticationTestCaseMixin, make_id_token, make_local_token, make_jwt
 from rest_framework.permissions import BasePermission
 from rest_framework.views import APIView
 
@@ -129,3 +129,23 @@ class TestJWTAuthentication(AuthenticationTestCaseMixin, TestCase):
         self.assertEqual(resp.status_code, 401)
         logger_mock.exception.assert_called_once_with(
             'Invalid Authorization header. JWT Signature verification failed.')
+
+    def test_should_fail_without_aud_claim(self):
+        auth = 'JWT ' + make_id_token(self.username, aud=None)
+        resp = self.client.get('/test/', HTTP_AUTHORIZATION=auth)
+        self.assertEqual(resp.status_code, 401)
+
+    def test_should_fail_without_iss_claim(self):
+        auth = 'JWT ' + make_id_token(self.username, iss=None)
+        resp = self.client.get('/test/', HTTP_AUTHORIZATION=auth)
+        self.assertEqual(resp.status_code, 401)
+
+    def test_should_fail_without_exp_claim(self):
+        auth = 'JWT ' + make_id_token(self.username, exp=None)
+        resp = self.client.get('/test/', HTTP_AUTHORIZATION=auth)
+        self.assertEqual(resp.status_code, 401)
+
+    def test_should_fail_without_nbf_claim(self):
+        auth = 'JWT ' + make_id_token(self.username, nbf=None)
+        resp = self.client.get('/test/', HTTP_AUTHORIZATION=auth)
+        self.assertEqual(resp.status_code, 401)

--- a/tests/test_authentication.py
+++ b/tests/test_authentication.py
@@ -4,12 +4,10 @@ from authlib.jose.errors import BadSignatureError, DecodeError
 from django.http import HttpResponse
 from django.test import TestCase
 from django.urls import re_path as url
-from oidc_auth.authentication import (BearerTokenAuthentication,
-                                      JSONWebTokenAuthentication,
+from oidc_auth.authentication import (JSONWebTokenAuthentication,
                                       JWTToken,
                                       UserInfo,)
 from oidc_auth.test import AuthenticationTestCaseMixin, make_id_token
-from rest_framework.exceptions import AuthenticationFailed
 from rest_framework.permissions import BasePermission
 from rest_framework.views import APIView
 
@@ -20,9 +18,9 @@ else:
         pass
 
 try:
-    from unittest.mock import Mock, PropertyMock, patch
+    from unittest.mock import patch
 except ImportError:
-    from mock import Mock, PropertyMock, patch
+    from mock import patch
 
 
 class TokenPermission(BasePermission):
@@ -40,7 +38,6 @@ class MockView(APIView):
     permission_classes = (TokenPermission,)
     authentication_classes = (
         JSONWebTokenAuthentication,
-        BearerTokenAuthentication
     )
 
     def get(self, request):
@@ -50,104 +47,6 @@ class MockView(APIView):
 urlpatterns = [
     url(r'^test/$', MockView.as_view(), name="testview")
 ]
-
-
-class TestBearerAuthentication(AuthenticationTestCaseMixin, TestCase):
-    urls = __name__
-
-    def setUp(self):
-        super(TestBearerAuthentication, self).setUp()
-        self.openid_configuration = {
-            'issuer': 'http://accounts.example.com/dex',
-            'authorization_endpoint': 'http://accounts.example.com/dex/auth',
-            'token_endpoint': 'http://accounts.example.com/dex/token',
-            'jwks_uri': 'http://accounts.example.com/dex/keys',
-            'response_types_supported': ['code'],
-            'subject_types_supported': ['public'],
-            'id_token_signing_alg_values_supported': ['RS256'],
-            'scopes_supported': ['openid', 'email', 'groups', 'profile', 'offline_access'],
-            'token_endpoint_auth_methods_supported': ['client_secret_basic'],
-            'claims_supported': [
-                'aud', 'email', 'email_verified', 'exp', 'iat', 'iss', 'locale',
-                'name', 'sub'
-            ],
-            'userinfo_endpoint': 'http://sellers.example.com/v1/sellers/'
-        }
-
-    def test_using_valid_bearer_token(self):
-        self.responder.set_response(
-            'http://example.com/userinfo', {'sub': self.username})
-        auth = 'Bearer abcdefg'
-        resp = self.client.get('/test/', HTTP_AUTHORIZATION=auth)
-        self.assertEqual(resp.content.decode(), 'a')
-        self.assertEqual(resp.status_code, 200)
-        self.mock_get.assert_called_with(
-            'http://example.com/userinfo', headers={'Authorization': auth})
-
-    def test_cache_of_valid_bearer_token(self):
-        self.responder.set_response(
-            'http://example.com/userinfo', {'sub': self.username})
-        auth = 'Bearer egergerg'
-        resp = self.client.get('/test/', HTTP_AUTHORIZATION=auth)
-        self.assertEqual(resp.status_code, 200)
-
-        # Token expires, but validity is cached
-        self.responder.set_response('http://example.com/userinfo', "", 401)
-        resp = self.client.get('/test/', HTTP_AUTHORIZATION=auth)
-        self.assertEqual(resp.status_code, 200)
-
-    def test_using_invalid_bearer_token(self):
-        self.responder.set_response('http://example.com/userinfo', "", 401)
-        auth = 'Bearer hjikasdf'
-        resp = self.client.get('/test/', HTTP_AUTHORIZATION=auth)
-        self.assertEqual(resp.status_code, 401)
-
-    def test_cache_of_invalid_bearer_token(self):
-        self.responder.set_response('http://example.com/userinfo', "", 401)
-        auth = 'Bearer feegrgeregreg'
-        resp = self.client.get('/test/', HTTP_AUTHORIZATION=auth)
-        self.assertEqual(resp.status_code, 401)
-
-        # Token becomes valid
-        self.responder.set_response(
-            'http://example.com/userinfo', {'sub': self.username})
-        resp = self.client.get('/test/', HTTP_AUTHORIZATION=auth)
-        self.assertEqual(resp.status_code, 200)
-
-    def test_using_malformed_bearer_token(self):
-        auth = 'Bearer abc def'
-        resp = self.client.get('/test/', HTTP_AUTHORIZATION=auth)
-        self.assertEqual(resp.status_code, 401)
-
-    def test_using_missing_bearer_token(self):
-        auth = 'Bearer'
-        resp = self.client.get('/test/', HTTP_AUTHORIZATION=auth)
-        self.assertEqual(resp.status_code, 401)
-
-    def test_using_inaccessible_userinfo_endpoint(self):
-        self.mock_get.side_effect = ConnectionError
-        auth = 'Bearer'
-        resp = self.client.get('/test/', HTTP_AUTHORIZATION=auth)
-        self.assertEqual(resp.status_code, 401)
-
-    def test_get_user_info_endpoint(self):
-        with patch('oidc_auth.authentication.BaseOidcAuthentication.oidc_config', new_callable=PropertyMock) as oidc_config_mock:
-            oidc_config_mock.return_value = self.openid_configuration
-            authentication = BearerTokenAuthentication()
-            response_mock = Mock(return_value=Mock(status_code=200,
-                                                   json=Mock(return_value={}),
-                                                   raise_for_status=Mock(return_value=None)))
-            with patch('oidc_auth.authentication.requests.get', response_mock):
-                result = authentication.get_userinfo(b'token')
-                assert result == {}
-
-    def test_get_user_info_endpoint_with_missing_field(self):
-        self.openid_configuration.pop('userinfo_endpoint')
-        with patch('oidc_auth.authentication.BaseOidcAuthentication.oidc_config', new_callable=PropertyMock) as oidc_config_mock:
-            oidc_config_mock.return_value = self.openid_configuration
-            authentication = BearerTokenAuthentication()
-            with self.assertRaisesMessage(AuthenticationFailed, 'userinfo_endpoint'):
-                authentication.get_userinfo(b'faketoken')
 
 
 class TestJWTAuthentication(AuthenticationTestCaseMixin, TestCase):

--- a/tests/test_authentication.py
+++ b/tests/test_authentication.py
@@ -1,5 +1,5 @@
 import sys
-
+import logging
 from authlib.jose.errors import BadSignatureError, DecodeError
 from django.http import HttpResponse
 from django.test import TestCase
@@ -21,6 +21,8 @@ try:
     from unittest.mock import patch
 except ImportError:
     from mock import patch
+
+logging.basicConfig()
 
 
 class TokenPermission(BasePermission):

--- a/tests/test_authentication.py
+++ b/tests/test_authentication.py
@@ -165,11 +165,6 @@ class TestJWTAuthentication(AuthenticationTestCaseMixin, TestCase):
         resp = self.client.get('/test/', HTTP_AUTHORIZATION=auth)
         self.assertEqual(resp.status_code, 401)
 
-    def test_with_old_jwt(self):
-        auth = 'JWT ' + make_id_token(self.user.username, iat=13151351)
-        resp = self.client.get('/test/', HTTP_AUTHORIZATION=auth)
-        self.assertEqual(resp.status_code, 401)
-
     def test_with_invalid_issuer(self):
         auth = 'JWT ' + \
                make_id_token(self.user.username, iss='http://something.com')

--- a/tox.ini
+++ b/tox.ini
@@ -26,4 +26,4 @@ deps =
     drf311: djangorestframework==3.11.*
     drf312: djangorestframework==3.12.*
     drf313: djangorestframework==3.13.*
-    jwt: pyjwt
+    jwt: pyjwt==2.6.*

--- a/tox.ini
+++ b/tox.ini
@@ -1,8 +1,8 @@
 [tox]
 envlist =
-  #  {py37,py38,py39}-django22-drf{311,312,313}
-  #  {py37,py38,py39,py310}-django32-drf{311,312,313}
-  #  {py38,py39,py310}-django40-drf{313}
+    {py37,py38,py39}-django22-drf{311,312,313}
+    {py37,py38,py39,py310}-django32-drf{311,312,313}
+    {py38,py39,py310}-django40-drf{313}
     {py38}-django40-drf{313}
 
 [gh-actions]

--- a/tox.ini
+++ b/tox.ini
@@ -26,4 +26,3 @@ deps =
     drf311: djangorestframework==3.11.*
     drf312: djangorestframework==3.12.*
     drf313: djangorestframework==3.13.*
-    jwt: pyjwt==2.6.*

--- a/tox.ini
+++ b/tox.ini
@@ -3,7 +3,7 @@ envlist =
   #  {py37,py38,py39}-django22-drf{311,312,313}
   #  {py37,py38,py39,py310}-django32-drf{311,312,313}
   #  {py38,py39,py310}-django40-drf{313}
-    {py38}-django40-drf{313}-jwt
+    {py38}-django40-drf{313}
 
 [gh-actions]
 python =

--- a/tox.ini
+++ b/tox.ini
@@ -1,8 +1,9 @@
 [tox]
 envlist =
-    {py37,py38,py39}-django22-drf{311,312,313}
-    {py37,py38,py39,py310}-django32-drf{311,312,313}
-    {py38,py39,py310}-django40-drf{313}
+  #  {py37,py38,py39}-django22-drf{311,312,313}
+  #  {py37,py38,py39,py310}-django32-drf{311,312,313}
+  #  {py38,py39,py310}-django40-drf{313}
+    {py38}-django40-drf{313}-jwt
 
 [gh-actions]
 python =
@@ -25,3 +26,4 @@ deps =
     drf311: djangorestframework==3.11.*
     drf312: djangorestframework==3.12.*
     drf313: djangorestframework==3.13.*
+    jwt: pyjwt


### PR DESCRIPTION
Contains big changes

- move away from oidc focus, now supports any jwks endpoint
- supports file containing public key instead of oidc/jwks endpoint
- supports multiple token sources
- uses pyjwt as main decoder, as its a bit cleaner than authlib imo