### PR TITLE
Do not call basicconfig

### DIFF
--- a/oidc_auth/authentication.py
+++ b/oidc_auth/authentication.py
@@ -19,7 +19,6 @@ from rest_framework.exceptions import AuthenticationFailed
 from .settings import api_settings
 from .util import cache
 
-logging.basicConfig()
 logger = logging.getLogger(__name__)
 
 


### PR DESCRIPTION
Bad idea to call basicconfig in a library, if the app using the library also configured logging then you risk getting duplicates and all sorts of trouble