### PR TITLE
Allow multiple issuers

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -13,6 +13,7 @@ django = "*"
 djangorestframework = "*"
 authlib = "*"
 requests = "*"
+pyjwt = "*"
 
 [requires]
 python_version = "3.10"

--- a/README.md
+++ b/README.md
@@ -35,21 +35,26 @@ registered as the default authentication classes.
 And configure the module itself in settings.py:
 ```py
 OIDC_AUTH = {
-    # Specify OpenID Connect endpoint. Configuration will be
-    # automatically done based on the discovery document found
-    # at <endpoint>/.well-known/openid-configuration
-    'OIDC_ENDPOINT': 'https://accounts.google.com',
-
-    # The Claims Options can now be defined by a static string.
+    # Define multiple issuers, each with
+    # an `OIDC_ENDPOINT` and `OIDC_CLAIMS_OPTIONS` value.
+    # The key for each issuer in the dict will be the expected value for
+    # the 'iss' claim in tokens from that issuer.
+    # Configuration will be automatically done based on the discover
+    # document found at <OIDC_ENDPOINT>/.well-known/openid-configuration.
+    # The Claims Options can now be defined according to this documentation:
     # ref: https://docs.authlib.org/en/latest/jose/jwt.html#jwt-payload-claims-validation
-    # The old OIDC_AUDIENCES option is removed in favor of this new option.
     # `aud` is only required, when you set it as an essential claim.
-    'OIDC_CLAIMS_OPTIONS': {
-        'aud': {
-            'values': ['myapp'],
-            'essential': True,
+    'JWT_ISSUERS': {
+        'https://google.com': {
+            'OIDC_ENDPOINT': 'https://accounts.google.com',
+            'OIDC_CLAIM_OPTIONS': {
+                'aud': {
+                    'values': ['myapp']
+                    'essential': True,
+                }
+            },
         }
-    },
+    }
 
     # (Optional) Function that resolves id_token into user.
     # This function receives a request and an id_token dict and expects to

--- a/oidc_auth/authentication.py
+++ b/oidc_auth/authentication.py
@@ -7,8 +7,8 @@ from authlib.jose.errors import (BadSignatureError, DecodeError,
                                  ExpiredTokenError, JoseError)
 from authlib.oidc.core.claims import IDToken
 from authlib.oidc.discovery import get_well_known_url
+import jwt as pyjwt
 from django.utils.encoding import smart_str
-from django.utils.functional import cached_property
 from django.utils.translation import gettext as _
 from requests import request
 from requests.exceptions import HTTPError
@@ -86,25 +86,25 @@ class JSONWebTokenAuthentication(BaseAuthentication):
 
     www_authenticate_realm = 'api'
 
-    @property
     @cache(ttl=api_settings.OIDC_BEARER_TOKEN_EXPIRATION_TIME)
-    def oidc_config(self):
+    def oidc_config(self, oidc_endpoint):
         return requests.get(
             get_well_known_url(
-                api_settings.OIDC_ENDPOINT,
+                oidc_endpoint,
                 external=True
             )
         ).json()
 
-    @property
-    def claims_options(self):
+    def claims_options(self, issuer):
         _claims_options = {
             'iss': {
                 'essential': True,
-                'values': [self.issuer]
+                'values': [issuer]
             }
         }
-        for key, value in api_settings.OIDC_CLAIMS_OPTIONS.items():
+        issuer_config = self.get_issuer_config(issuer)
+        issuer_options = issuer_config['OIDC_CLAIMS_OPTIONS']
+        for key, value in issuer_options.items():
             _claims_options[key] = value
         return _claims_options
 
@@ -136,28 +136,28 @@ class JSONWebTokenAuthentication(BaseAuthentication):
 
         return auth[1]
 
-    def jwks(self):
-        return JsonWebKey.import_key_set(self.jwks_data())
+    def jwks(self, oidc_endpoint):
+        oidc_config = self.oidc_config(oidc_endpoint)
+        jwks_uri = oidc_config['jwks_uri']
+        return JsonWebKey.import_key_set(self.jwks_data(jwks_uri))
 
     @cache(ttl=api_settings.OIDC_JWKS_EXPIRATION_TIME)
-    def jwks_data(self):
-        r = request("GET", self.oidc_config['jwks_uri'], allow_redirects=True)
+    def jwks_data(self, jwks_uri):
+        r = request("GET", jwks_uri, allow_redirects=True)
         r.raise_for_status()
         return r.json()
 
-    @cached_property
-    def issuer(self):
-        return self.oidc_config['issuer']
-
     def decode_jwt(self, jwt_value):
         try:
+            issuer = self.get_issuer_from_raw_token(jwt_value)
+            key = self.get_key_for_issuer(issuer)
             id_token = jwt.decode(
                 jwt_value.decode('ascii'),
-                self.jwks(),
+                key,
                 claims_cls=IDToken,
-                claims_options=self.claims_options
+                claims_options=self.claims_options(issuer)
             )
-        except (BadSignatureError, DecodeError):
+        except (BadSignatureError, DecodeError, pyjwt.exceptions.DecodeError):
             msg = _(
                 'Invalid Authorization header. JWT Signature verification failed.')
             logger.exception(msg)
@@ -181,6 +181,28 @@ class JSONWebTokenAuthentication(BaseAuthentication):
         except JoseError as e:
             msg = _(str(type(e)) + str(e))
             raise AuthenticationFailed(msg)
+
+    def get_key_for_issuer(self, issuer):
+        issuer_config = self.get_issuer_config(issuer)
+        oidc_endpoint = issuer_config['OIDC_ENDPOINT']
+        key = self.jwks(oidc_endpoint)
+        return key
+
+    def get_issuer_from_raw_token(self, token):
+        claims = self.get_claims_without_validation(token)
+        if 'iss' not in claims:
+            raise AuthenticationFailed("Token is missing the 'iss' claim")
+        return claims['iss']
+
+    def get_claims_without_validation(self, token):
+        """Raises pyjwt.exceptions.DecodeError if token could not be decoded"""
+        return pyjwt.decode(token, options={"verify_signature": False})
+
+    def get_issuer_config(self, target_issuer):
+        issuer = api_settings.JWT_ISSUERS.get(target_issuer)
+        if not issuer:
+            raise AuthenticationFailed("Invalid 'iss' claim")
+        return issuer
 
     def authenticate_header(self, request):
         return 'JWT realm="{0}"'.format(self.www_authenticate_realm)

--- a/oidc_auth/settings.py
+++ b/oidc_auth/settings.py
@@ -4,17 +4,15 @@ from rest_framework.settings import APISettings
 USER_SETTINGS = getattr(settings, 'OIDC_AUTH', None)
 
 DEFAULTS = {
-    'OIDC_ENDPOINT': None,
-
-    # Currently unimplemented
-    'OIDC_ENDPOINTS': [],
-
-    # The Claims Options can now be defined by a static string.
+    # Define multiple issuers, each with
+    # an `OIDC_ENDPOINT` and `OIDC_CLAIMS_OPTIONS` value.
+    # The key for each issuer in the dict will be the expected value for
+    # the 'iss' claim in tokens from that issuer.
+    # Configuration will be automatically done based on the discover
+    # document found at <OIDC_ENDPOINT>/.well-known/openid-configuration.
+    # The Claims Options can now be defined according to this documentation:
     # ref: https://docs.authlib.org/en/latest/jose/jwt.html#jwt-payload-claims-validation
-    'OIDC_CLAIMS_OPTIONS': {
-        'aud': {
-            'essential': True,
-        }
+    'JWT_ISSUERS': {
     },
 
     # Time before JWKS will be refreshed

--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,8 @@ setup(
         'cryptography>=2.6',
         'django>=2.2.0',
         'djangorestframework>=3.11.0',
-        'requests>=2.20.0'
+        'requests>=2.20.0',
+        'pyjwt>=2.6.0',
     ],
     classifiers=[
         'Development Status :: 4 - Beta',

--- a/tests/settings.py
+++ b/tests/settings.py
@@ -10,12 +10,16 @@ REST_FRAMEWORK = {
 }
 ROOT_URLCONF = 'tests.test_authentication'
 OIDC_AUTH = {
-    'OIDC_ENDPOINT': 'http://example.com',
-    'OIDC_CLAIMS_OPTIONS': {
-        'aud': {
-            'values': ['you'],
-            'essential': True,
-        }
-    },
     'USERINFO_ENDPOINT': "http://example.com/userinfo",
+    'JWT_ISSUERS': {
+        'http://example.com': {
+            'OIDC_ENDPOINT': 'http://example.com',
+            'OIDC_CLAIMS_OPTIONS': {
+                'aud': {
+                    'values': ['you'],
+                    'essential': True,
+                }
+            }
+        }
+    }
 }

--- a/tests/settings.py
+++ b/tests/settings.py
@@ -17,4 +17,5 @@ OIDC_AUTH = {
             'essential': True,
         }
     },
+    'USERINFO_ENDPOINT': "http://example.com/userinfo",
 }

--- a/tests/test_authentication.py
+++ b/tests/test_authentication.py
@@ -131,23 +131,13 @@ class TestBearerAuthentication(AuthenticationTestCaseMixin, TestCase):
         self.assertEqual(resp.status_code, 401)
 
     def test_get_user_info_endpoint(self):
-        with patch('oidc_auth.authentication.BaseOidcAuthentication.oidc_config', new_callable=PropertyMock) as oidc_config_mock:
-            oidc_config_mock.return_value = self.openid_configuration
-            authentication = BearerTokenAuthentication()
-            response_mock = Mock(return_value=Mock(status_code=200,
-                                                   json=Mock(return_value={}),
-                                                   raise_for_status=Mock(return_value=None)))
-            with patch('oidc_auth.authentication.requests.get', response_mock):
-                result = authentication.get_userinfo(b'token')
-                assert result == {}
-
-    def test_get_user_info_endpoint_with_missing_field(self):
-        self.openid_configuration.pop('userinfo_endpoint')
-        with patch('oidc_auth.authentication.BaseOidcAuthentication.oidc_config', new_callable=PropertyMock) as oidc_config_mock:
-            oidc_config_mock.return_value = self.openid_configuration
-            authentication = BearerTokenAuthentication()
-            with self.assertRaisesMessage(AuthenticationFailed, 'userinfo_endpoint'):
-                authentication.get_userinfo(b'faketoken')
+        authentication = BearerTokenAuthentication()
+        response_mock = Mock(return_value=Mock(status_code=200,
+                                                json=Mock(return_value={}),
+                                                raise_for_status=Mock(return_value=None)))
+        with patch('oidc_auth.authentication.requests.get', response_mock):
+            result = authentication.get_userinfo(b'token')
+            assert result == {}
 
 
 class TestJWTAuthentication(AuthenticationTestCaseMixin, TestCase):


### PR DESCRIPTION
Adds support for multiple JWT issuers.

Makes Bearer auth rely on having the INFO_ENDPOINT setting configured. Previously this could be gotten
from OIDC_ENDPOINT, but since the OIDC_ENDPOINT now rely on knowing the Issuer of the token, its no longer
suitable for using with Bearer auth.

Adds response content to test output if the test fail because of a response status code or something