### PR TITLE
Increase test flexibility

### DIFF
--- a/oidc_auth/authentication.py
+++ b/oidc_auth/authentication.py
@@ -100,7 +100,10 @@ class JSONWebTokenAuthentication(BaseAuthentication):
             'iss': {
                 'essential': True,
                 'values': [issuer]
-            }
+            },
+            'nbf': {
+                'essential': True,
+            },
         }
         issuer_config = self.get_issuer_config(issuer)
         issuer_options = issuer_config['OIDC_CLAIMS_OPTIONS']

--- a/oidc_auth/test.py
+++ b/oidc_auth/test.py
@@ -14,17 +14,20 @@ def make_id_token(sub,
                   aud='you',
                   exp=999999999999,  # tests will start failing in September 33658
                   iat=999999999999,
+                  nbf=13151351,
                   **kwargs):
-    return make_jwt(
-        dict(
+    payload = dict(
             iss=iss,
             aud=aud,
             exp=exp,
             iat=iat,
+            nbf=nbf,
             sub=str(sub),
             **kwargs
         )
-    ).decode('ascii')
+    # remove keys with empty values
+    clean_payload = dict((k, v) for k, v in payload.items() if v)
+    return make_jwt(clean_payload).decode('ascii')
 
 
 def make_jwt(payload):

--- a/tests/test_authentication.py
+++ b/tests/test_authentication.py
@@ -219,3 +219,28 @@ class TestJWTAuthentication(AuthenticationTestCaseMixin, TestCase):
         self.assertEqual(resp.status_code, 401, resp.content)
         logger_mock.exception.assert_called_once_with(
             'Invalid Authorization header. JWT Signature verification failed.')
+
+    def test_should_fail_without_aud_claim(self):
+        auth = 'JWT ' + make_id_token(self.username, aud=None)
+        resp = self.client.get('/test/', HTTP_AUTHORIZATION=auth)
+        self.assertEqual(resp.status_code, 401, resp.content)
+
+    def test_should_fail_without_iss_claim(self):
+        auth = 'JWT ' + make_id_token(self.username, iss=None)
+        resp = self.client.get('/test/', HTTP_AUTHORIZATION=auth)
+        self.assertEqual(resp.status_code, 401, resp.content)
+
+    def test_should_fail_without_exp_claim(self):
+        auth = 'JWT ' + make_id_token(self.username, exp=None)
+        resp = self.client.get('/test/', HTTP_AUTHORIZATION=auth)
+        self.assertEqual(resp.status_code, 401, resp.content)
+
+    def test_should_fail_without_nbf_claim(self):
+        auth = 'JWT ' + make_id_token(self.username, nbf=None)
+        resp = self.client.get('/test/', HTTP_AUTHORIZATION=auth)
+        self.assertEqual(resp.status_code, 401, resp.content)
+
+    def test_should_fail_without_iat_kid(self):
+        auth = 'JWT ' + make_id_token(self.username, iat=None)
+        resp = self.client.get('/test/', HTTP_AUTHORIZATION=auth)
+        self.assertEqual(resp.status_code, 401, resp.content)


### PR DESCRIPTION
Makes it possible to say that default claims should NOT be in the token at all by setting its value to None.
Adds a few more tests. One tests checks the it fails if token does not have `iat` claim. this is the current beehaviour,
so i added the test to document it but not sure we want `ìat` to be mandatory.
made `nbf` claim by default non-optional, but can be made optional through the OIDC_CLAIMS_OPTIONS setting, this does not work for `iat`.