### PR TITLE
Support pem keys

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,14 +35,14 @@ registered as the default authentication classes.
 And configure the module itself in settings.py:
 ```py
 OIDC_AUTH = {
-    # Define multiple issuers, each with
-    # an `OIDC_ENDPOINT` and `OIDC_CLAIMS_OPTIONS` value.
+    # Define multiple issuers in here, each with
+    # an `type`, `key` and `OIDC_CLAIMS_OPTIONS` value.
     # The key for each issuer in the dict will be the expected value for
     # the 'iss' claim in tokens from that issuer.
-    # Configuration will be automatically done based on the discover
-    # document found at <OIDC_ENDPOINT>/.well-known/openid-configuration.
     # The Claims Options can now be defined according to this documentation:
     # ref: https://docs.authlib.org/en/latest/jose/jwt.html#jwt-payload-claims-validation
+    # `type` can be "PEM" or "OIDC". If "PEM", then `key` must be a public key
+    # in PEM format. if "OIDC`, then `key` must be a OIDC endpoint
     # `aud` is only required, when you set it as an essential claim.
     'JWT_ISSUERS': {
         'https://google.com': {

--- a/oidc_auth/authentication.py
+++ b/oidc_auth/authentication.py
@@ -2,7 +2,7 @@ import logging
 import time
 
 import requests
-from authlib.jose import JsonWebKey, jwt
+from authlib.jose import JsonWebKey, JsonWebToken
 from authlib.jose.errors import (BadSignatureError, DecodeError,
                                  ExpiredTokenError, JoseError)
 from authlib.oidc.core.claims import IDToken
@@ -21,6 +21,7 @@ from .util import cache
 
 logger = logging.getLogger(__name__)
 
+jwt = JsonWebToken(['RS256', 'RS384', 'RS512'])
 
 def get_user_none(request, id_token):
     return None

--- a/oidc_auth/authentication.py
+++ b/oidc_auth/authentication.py
@@ -187,8 +187,14 @@ class JSONWebTokenAuthentication(BaseAuthentication):
 
     def get_key_for_issuer(self, issuer):
         issuer_config = self.get_issuer_config(issuer)
-        oidc_endpoint = issuer_config['OIDC_ENDPOINT']
-        key = self.jwks(oidc_endpoint)
+        key = issuer_config['key']
+        key_type = issuer_config['type']
+        if key_type not in ['OIDC', 'PEM']:
+            raise ValueError(f"{key_type} is not a valid type")
+        if key_type == 'OIDC':
+            key = self.jwks(key)
+        elif key_type == 'PEM':
+            key = bytes(key, encoding='utf-8')
         return key
 
     def get_issuer_from_raw_token(self, token):

--- a/oidc_auth/settings.py
+++ b/oidc_auth/settings.py
@@ -4,14 +4,14 @@ from rest_framework.settings import APISettings
 USER_SETTINGS = getattr(settings, 'OIDC_AUTH', None)
 
 DEFAULTS = {
-    # Define multiple issuers, each with
-    # an `OIDC_ENDPOINT` and `OIDC_CLAIMS_OPTIONS` value.
+    # Define multiple issuers in here, each with
+    # an `type`, `key` and `OIDC_CLAIMS_OPTIONS` value.
     # The key for each issuer in the dict will be the expected value for
     # the 'iss' claim in tokens from that issuer.
-    # Configuration will be automatically done based on the discover
-    # document found at <OIDC_ENDPOINT>/.well-known/openid-configuration.
     # The Claims Options can now be defined according to this documentation:
     # ref: https://docs.authlib.org/en/latest/jose/jwt.html#jwt-payload-claims-validation
+    # `type` can be "PEM" or "OIDC". If "PEM", then `key` must be a public key
+    # in PEM format. if "OIDC`, then `key` must be a OIDC endpoint
     'JWT_ISSUERS': {
     },
 

--- a/oidc_auth/test.py
+++ b/oidc_auth/test.py
@@ -7,6 +7,8 @@ except ImportError:
     from mock import patch, Mock
 from cryptography.hazmat.primitives import serialization as crypto_serialization
 
+jwt = JsonWebToken(['RS256', 'RS384', 'RS512'])
+
 jwk_key = RSAKey.generate_key(is_private=True)
 pem_key = RSAKey.generate_key(is_private=True)
 
@@ -46,7 +48,6 @@ def make_local_token():
     return make_id_token(sub="username", iss="local", key=pem_key, aud="local_aud")
 
 def make_jwt(payload, key):
-    jwt = JsonWebToken(['RS256'])
     jws = jwt.encode(
         {'alg': 'RS256', 'kid': key.as_dict(add_kid=True).get('kid')}, payload, key=key)
     return jws

--- a/oidc_auth/test.py
+++ b/oidc_auth/test.py
@@ -22,7 +22,7 @@ def get_public_key(key):
 
 PEM_PUBLIC_KEY = get_public_key(pem_key)
 
-def make_id_token(sub,
+def make_id_token(sub="username",
                   iss='http://example.com',
                   aud='you',
                   exp=999999999999,  # tests will start failing in September 33658
@@ -45,7 +45,7 @@ def make_id_token(sub,
 
 
 def make_local_token():
-    return make_id_token(sub="username", iss="local", key=pem_key, aud="local_aud")
+    return make_id_token(iss="local", key=pem_key, aud="local_aud")
 
 def make_jwt(payload, key):
     jws = jwt.encode(

--- a/tests/settings.py
+++ b/tests/settings.py
@@ -1,3 +1,4 @@
+from oidc_auth.test import PEM_PUBLIC_KEY
 SECRET_KEY = 'secret'
 DATABASES = {
     'default': {
@@ -13,12 +14,23 @@ OIDC_AUTH = {
     'USERINFO_ENDPOINT': "http://example.com/userinfo",
     'JWT_ISSUERS': {
         'http://example.com': {
-            'OIDC_ENDPOINT': 'http://example.com',
+            'type': "OIDC",
+            'key': 'http://example.com',
             'OIDC_CLAIMS_OPTIONS': {
                 'aud': {
                     'values': ['you'],
                     'essential': True,
-                }
+                },
+            }
+        },
+        'local': {
+            'type': "PEM",
+            'key': PEM_PUBLIC_KEY,
+            'OIDC_CLAIMS_OPTIONS': {
+                'aud': {
+                    'values': ['local_aud'],
+                    'essential': True,
+                },
             }
         }
     }

--- a/tests/test_authentication.py
+++ b/tests/test_authentication.py
@@ -144,7 +144,7 @@ class TestJWTAuthentication(AuthenticationTestCaseMixin, TestCase):
     urls = __name__
 
     def test_using_valid_jwt(self):
-        auth = 'JWT ' + make_id_token(self.username)
+        auth = 'JWT ' + make_id_token()
         resp = self.client.get('/test/', HTTP_AUTHORIZATION=auth)
         self.assertEqual(resp.status_code, 200, resp.content)
         self.assertEqual(resp.content.decode(), 'a', resp.content)
@@ -164,44 +164,44 @@ class TestJWTAuthentication(AuthenticationTestCaseMixin, TestCase):
         self.assertEqual(resp.status_code, 401, resp.content)
 
     def test_with_expired_jwt(self):
-        auth = 'JWT ' + make_id_token(self.username, exp=13151351)
+        auth = 'JWT ' + make_id_token(exp=13151351)
         resp = self.client.get('/test/', HTTP_AUTHORIZATION=auth)
         self.assertEqual(resp.status_code, 401, resp.content)
 
     def test_with_invalid_issuer(self):
         auth = 'JWT ' + \
-               make_id_token(self.username, iss='http://something.com')
+               make_id_token(iss='http://something.com')
         resp = self.client.get('/test/', HTTP_AUTHORIZATION=auth)
         self.assertEqual(resp.status_code, 401, resp.content)
 
     def test_with_invalid_audience(self):
-        auth = 'JWT ' + make_id_token(self.username, aud='somebody')
+        auth = 'JWT ' + make_id_token(aud='somebody')
         resp = self.client.get('/test/', HTTP_AUTHORIZATION=auth)
         self.assertEqual(resp.status_code, 401, resp.content)
 
     def test_with_too_new_jwt(self):
-        auth = 'JWT ' + make_id_token(self.username, nbf=999999999999)
+        auth = 'JWT ' + make_id_token(nbf=999999999999)
         resp = self.client.get('/test/', HTTP_AUTHORIZATION=auth)
         self.assertEqual(resp.status_code, 401, resp.content)
 
     def test_with_multiple_audiences(self):
-        auth = 'JWT ' + make_id_token(self.username, aud=['you', 'me'])
+        auth = 'JWT ' + make_id_token(aud=['you', 'me'])
         resp = self.client.get('/test/', HTTP_AUTHORIZATION=auth)
         self.assertEqual(resp.status_code, 200, resp.content)
 
     def test_with_invalid_multiple_audiences(self):
-        auth = 'JWT ' + make_id_token(self.username, aud=['we', 'me'])
+        auth = 'JWT ' + make_id_token(aud=['we', 'me'])
         resp = self.client.get('/test/', HTTP_AUTHORIZATION=auth)
         self.assertEqual(resp.status_code, 401, resp.content)
 
     def test_with_multiple_audiences_and_authorized_party(self):
         auth = 'JWT ' + \
-               make_id_token(self.username, aud=['you', 'me'], azp='you')
+               make_id_token(aud=['you', 'me'], azp='you')
         resp = self.client.get('/test/', HTTP_AUTHORIZATION=auth)
         self.assertEqual(resp.status_code, 200, resp.content)
 
     def test_with_invalid_signature(self):
-        auth = 'JWT ' + make_id_token(self.username)
+        auth = 'JWT ' + make_id_token()
         resp = self.client.get('/test/', HTTP_AUTHORIZATION=auth + 'x')
         self.assertEqual(resp.status_code, 401, resp.content)
 
@@ -211,7 +211,7 @@ class TestJWTAuthentication(AuthenticationTestCaseMixin, TestCase):
         self,
         logger_mock, decode
     ):
-        auth = 'JWT ' + make_id_token(self.username)
+        auth = 'JWT ' + make_id_token()
         decode.side_effect = DecodeError, BadSignatureError
 
         resp = self.client.get('/test/', HTTP_AUTHORIZATION=auth)
@@ -221,27 +221,27 @@ class TestJWTAuthentication(AuthenticationTestCaseMixin, TestCase):
             'Invalid Authorization header. JWT Signature verification failed.')
 
     def test_should_fail_without_aud_claim(self):
-        auth = 'JWT ' + make_id_token(self.username, aud=None)
+        auth = 'JWT ' + make_id_token(aud=None)
         resp = self.client.get('/test/', HTTP_AUTHORIZATION=auth)
         self.assertEqual(resp.status_code, 401, resp.content)
 
     def test_should_fail_without_iss_claim(self):
-        auth = 'JWT ' + make_id_token(self.username, iss=None)
+        auth = 'JWT ' + make_id_token(iss=None)
         resp = self.client.get('/test/', HTTP_AUTHORIZATION=auth)
         self.assertEqual(resp.status_code, 401, resp.content)
 
     def test_should_fail_without_exp_claim(self):
-        auth = 'JWT ' + make_id_token(self.username, exp=None)
+        auth = 'JWT ' + make_id_token(exp=None)
         resp = self.client.get('/test/', HTTP_AUTHORIZATION=auth)
         self.assertEqual(resp.status_code, 401, resp.content)
 
     def test_should_fail_without_nbf_claim(self):
-        auth = 'JWT ' + make_id_token(self.username, nbf=None)
+        auth = 'JWT ' + make_id_token(nbf=None)
         resp = self.client.get('/test/', HTTP_AUTHORIZATION=auth)
         self.assertEqual(resp.status_code, 401, resp.content)
 
     def test_should_fail_without_iat_kid(self):
-        auth = 'JWT ' + make_id_token(self.username, iat=None)
+        auth = 'JWT ' + make_id_token(iat=None)
         resp = self.client.get('/test/', HTTP_AUTHORIZATION=auth)
         self.assertEqual(resp.status_code, 401, resp.content)
 

--- a/tests/test_authentication.py
+++ b/tests/test_authentication.py
@@ -8,7 +8,7 @@ from oidc_auth.authentication import (BearerTokenAuthentication,
                                       JSONWebTokenAuthentication,
                                       JWTToken,
                                       UserInfo,)
-from oidc_auth.test import AuthenticationTestCaseMixin, make_id_token
+from oidc_auth.test import AuthenticationTestCaseMixin, make_id_token, make_local_token
 from rest_framework.exceptions import AuthenticationFailed
 from rest_framework.permissions import BasePermission
 from rest_framework.views import APIView
@@ -244,3 +244,9 @@ class TestJWTAuthentication(AuthenticationTestCaseMixin, TestCase):
         auth = 'JWT ' + make_id_token(self.username, iat=None)
         resp = self.client.get('/test/', HTTP_AUTHORIZATION=auth)
         self.assertEqual(resp.status_code, 401, resp.content)
+
+    def test_using_valid_jwt_and_local_issuer(self):
+        auth = 'JWT ' + make_local_token()
+        resp = self.client.get('/test/', HTTP_AUTHORIZATION=auth)
+        self.assertEqual(resp.status_code, 200, resp.content)
+        self.assertEqual(resp.content.decode(), 'a')


### PR DESCRIPTION
Adds support for PEM keys, and does some minor cleanup

Actual import change: limits allowed signature algorithms for the token. Without limiting it you risk certain security issues.