### PR TITLE
Set default iat to not be in the future in tests

### DIFF
--- a/oidc_auth/test.py
+++ b/oidc_auth/test.py
@@ -26,7 +26,7 @@ def make_id_token(sub="username",
                   iss='http://example.com',
                   aud='you',
                   exp=999999999999,  # tests will start failing in September 33658
-                  iat=999999999999,
+                  iat=13151351,
                   nbf=13151351,
                   key=jwk_key,
                   **kwargs):


### PR DESCRIPTION
Tests failed since tokens that should be valid had an invalid iat claim set to the future