### PR TITLE
Remove support for old django (and drf) versions and test newer versions

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,7 +24,7 @@ dependencies = [
     "authlib>=0.15.0",
     "cryptography>=2.6",
     "django>=4.2.0",
-    "djangorestframework>=3.14.0",
+    "djangorestframework>=3.15.0",
     "requests>=2.20.0",
     "pyjwt>=2.6.0",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,8 +23,8 @@ license-files = ["LICEN[CS]E*"]
 dependencies = [
     "authlib>=0.15.0",
     "cryptography>=2.6",
-    "django>=2.2.0",
-    "djangorestframework>=3.11.0",
+    "django>=4.2.0",
+    "djangorestframework>=3.14.0",
     "requests>=2.20.0",
     "pyjwt>=2.6.0",
 ]

--- a/setup.py
+++ b/setup.py
@@ -12,8 +12,8 @@ setup(
     install_requires=[
         'authlib>=0.15.0',
         'cryptography>=2.6',
-        'django>=2.2.0',
-        'djangorestframework>=3.11.0',
+        'django>=4.2.0',
+        'djangorestframework>=3.14.0',
         'requests>=2.20.0',
         'pyjwt>=2.6.0',
     ],

--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,7 @@ setup(
         'authlib>=0.15.0',
         'cryptography>=2.6',
         'django>=4.2.0',
-        'djangorestframework>=3.14.0',
+        'djangorestframework>=3.15.0',
         'requests>=2.20.0',
         'pyjwt>=2.6.0',
     ],

--- a/tox.ini
+++ b/tox.ini
@@ -1,7 +1,7 @@
 [tox]
 envlist =
-    {py39,py310,py311,py312,py313}-django{42}-drf{314,315,316}
-    {py310,py312,py313}-django{52}-drf{315,316}
+    {py39,py310,py311,py312}-django{42}-drf{315,316}
+    {py310,py311,py312,py313}-django{52}-drf{316}
 
 [gh-actions]
 python =

--- a/tox.ini
+++ b/tox.ini
@@ -1,8 +1,6 @@
 [tox]
 envlist =
-    {py39}-django22-drf{311,312,313}
-    {py39,py310}-django32-drf{311,312,313}
-    {py39,py310}-django40-drf{313}
+    {py39,py310}-django{42}-drf{314}
 
 [gh-actions]
 python =
@@ -17,9 +15,5 @@ setenv =
     DJANGO_SETTINGS_MODULE=tests.settings
     PYTHONPATH={toxinidir}
 deps =
-    django22: Django==2.2.*
-    django32: Django==3.2.*
-    django40: Django==4.0.*
-    drf311: djangorestframework==3.11.*
-    drf312: djangorestframework==3.12.*
-    drf313: djangorestframework==3.13.*
+    django42: Django==4.2.*
+    drf314: djangorestframework==3.14.*

--- a/tox.ini
+++ b/tox.ini
@@ -1,11 +1,15 @@
 [tox]
 envlist =
-    {py39,py310}-django{42}-drf{314}
+    {py39,py310,py311,py312,py313}-django{42}-drf{314,315,316}
+    {py310,py312,py313}-django{52}-drf{315,316}
 
 [gh-actions]
 python =
     3.9: py39
     3.10: py310
+    3.11: py311
+    3.12: py312
+    3.13: py313
 
 [testenv]
 commands =
@@ -16,4 +20,7 @@ setenv =
     PYTHONPATH={toxinidir}
 deps =
     django42: Django==4.2.*
+    django52: Django==5.2.*
     drf314: djangorestframework==3.14.*
+    drf315: djangorestframework==3.15.*
+    drf316: djangorestframework==3.15.*

--- a/tox.ini
+++ b/tox.ini
@@ -23,4 +23,4 @@ deps =
     django52: Django==5.2.*
     drf314: djangorestframework==3.14.*
     drf315: djangorestframework==3.15.*
-    drf316: djangorestframework==3.15.*
+    drf316: djangorestframework==3.16.*


### PR DESCRIPTION
Removes test and support for EOL django versions (and older drf that dont support django>=4.2).

Add envs for running tests on django 4.2 and 5.2, with python and drf versions that work with the respective versions (django5.2 requires python3.10 for instance, but 4.2 supports 3.9, and drf<3.15 does not work with django5.2).

Also runs tests for all django versions from 3.9 to 3.13